### PR TITLE
feat(remote): make update and removal recoverable

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -424,3 +424,11 @@ Queues and caches are bounded, and pane-owned resources are reclaimed on detach.
 - [Architecture and ownership](../docs/desktop/architecture.md)
 - [Performance measurements and guardrails](../docs/desktop/performance.md)
 - [Continuous integration](../docs/desktop/ci.md)
+
+### Remove an offline remote Workspace from the sidebar
+
+Choose **Hide from sidebar** in the remote Workspace's three-dot menu. This
+works offline, remembers the choice, and leaves remote work running. Restore it
+under **Remotes → Hidden Workspaces → Show**. Deleting remote Shells still
+requires the owner to be reachable; forgetting a machine's connection removes
+all its entries instead.

--- a/desktop/src/layout_state.rs
+++ b/desktop/src/layout_state.rs
@@ -50,17 +50,20 @@ pub struct Document {
     pub arrangements: BTreeMap<String, Arrangement>,
     pub minimized: Vec<String>,
     pub workspace_order: Vec<String>,
+    #[serde(default)]
+    pub hidden_remote_workspaces: BTreeMap<String, String>,
 }
 impl Default for Document {
     fn default() -> Self {
         Self {
-            version: 1,
+            version: 2,
             revision: String::new(),
             owner: String::new(),
             active: String::new(),
             arrangements: BTreeMap::new(),
             minimized: Vec::new(),
             workspace_order: Vec::new(),
+            hidden_remote_workspaces: BTreeMap::new(),
         }
     }
 }
@@ -128,14 +131,24 @@ impl Tree {
 }
 impl Document {
     pub fn validate(&self) -> Result<(), String> {
-        if self.version != 1 {
+        if self.version != 2 {
             return Err("unsupported layout state version; saved file retained".into());
         }
         if self.arrangements.len() > 256
             || self.minimized.len() > MAX_PANES
+            || self.hidden_remote_workspaces.len() > 256
             || self.workspace_order.len() > 4096
         {
             return Err("layout state exceeds bounds".into());
+        }
+        for (key, name) in &self.hidden_remote_workspaces {
+            if key.len() > 1024
+                || name.len() > 1024
+                || crate::remote::identity(key)
+                    .is_none_or(|id| id.node_id.is_empty() || id.inner_id.is_empty())
+            {
+                return Err("invalid hidden remote Workspace".into());
+            }
         }
         let mut total = 0;
         for arrangement in self.arrangements.values() {
@@ -203,7 +216,13 @@ fn read(path: &PathBuf) -> Result<Document, String> {
     if bytes.len() > MAX_BYTES {
         return Err("layout state exceeds 2 MiB".into());
     }
-    let document: Document = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    let mut document: Document = serde_json::from_slice(&bytes).map_err(|e| e.to_string())?;
+    if document.version == 1 {
+        // Version 1 had no sidebar visibility preferences. Preserve its geometry
+        // and revision while explicitly migrating to an empty hidden set.
+        document.hidden_remote_workspaces.clear();
+        document.version = 2;
+    }
     document.validate()?;
     Ok(document)
 }
@@ -357,6 +376,37 @@ mod tests {
         fs::create_dir(&path).unwrap();
         path
     }
+    #[test]
+    fn hidden_remote_workspaces_migrate_and_survive_reload() {
+        let root = temporary();
+        let path = root.join("layout.json");
+        let mut old = serde_json::to_value(fixture()).unwrap();
+        old["version"] = 1.into();
+        old.as_object_mut()
+            .unwrap()
+            .remove("hidden_remote_workspaces");
+        fs::write(&path, serde_json::to_vec(&old).unwrap()).unwrap();
+        let mut doc = read(&path).unwrap();
+        assert_eq!(doc.version, 2);
+        assert!(doc.hidden_remote_workspaces.is_empty());
+        assert_eq!(doc.arrangements, fixture().arrangements);
+        doc.hidden_remote_workspaces
+            .insert("remote:node-a:workspace-a".into(), "Offline work".into());
+        let mut store = Store {
+            path: path.clone(),
+            revision: doc.revision.clone(),
+        };
+        store.save(doc.clone()).unwrap();
+        assert_eq!(
+            read(&path).unwrap().hidden_remote_workspaces,
+            doc.hidden_remote_workspaces
+        );
+        doc.hidden_remote_workspaces
+            .insert("local-workspace".into(), "Local".into());
+        assert!(doc.validate().is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn layout_round_trip_preserves_geometry_identity_and_minimized_state() {
         let doc = fixture();

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -9,6 +9,7 @@ mod layout_persistence;
 mod layout_state;
 mod nodes;
 mod remote;
+mod remote_visibility;
 mod runtime;
 mod settings;
 mod subprocess;
@@ -1702,10 +1703,14 @@ impl Workspace {
     ) -> Self {
         let focus_handle = cx.focus_handle();
         window.focus(&focus_handle, cx);
-        let (boomux_overview, boomux_error) = match terminal::discover_overview() {
+        let (mut boomux_overview, boomux_error) = match terminal::discover_overview() {
             Ok(overview) => (overview, None),
             Err(error) => (BoomuxOverview::default(), Some(error)),
         };
+        remote_visibility::filter(
+            &mut boomux_overview,
+            &layout_session.document.hidden_remote_workspaces,
+        );
         let boomux_shells = boomux_overview
             .workspaces
             .iter()
@@ -2432,6 +2437,10 @@ impl Workspace {
     }
 
     fn set_boomux_overview(&mut self, mut overview: BoomuxOverview) {
+        remote_visibility::filter(
+            &mut overview,
+            &self.layout_document.hidden_remote_workspaces,
+        );
         reconcile_workspace_order(&mut self.workspace_order, &mut overview);
         reconcile_completed_agents(
             &mut self.previous_agent_states,
@@ -2959,19 +2968,31 @@ impl Workspace {
     }
 
     fn remove_resource_panes(&mut self, target: &SidebarResource, window: &mut Window) {
-        let pane_ids = self
-            .terminals
-            .iter()
-            .filter_map(|(id, pane)| {
-                let shell = pane.shell.as_ref()?;
-                let matches = match target {
-                    SidebarResource::Workspace { id, .. } => shell.workspace_id == *id,
-                    SidebarResource::Shell { id, .. } => shell.id == *id,
-                    SidebarResource::Connection { .. } => false,
-                };
-                matches.then_some(*id)
-            })
-            .collect::<Vec<_>>();
+        let pane_ids =
+            self.terminals
+                .iter()
+                .filter_map(|(id, pane)| {
+                    let workspace_id = pane
+                        .shell
+                        .as_ref()
+                        .map(|shell| &shell.workspace_id)
+                        .or_else(|| {
+                            pane.restored
+                                .as_ref()
+                                .and_then(|pane| pane.workspace.as_ref())
+                        });
+                    let shell_id =
+                        pane.shell.as_ref().map(|shell| &shell.id).or_else(|| {
+                            pane.restored.as_ref().and_then(|pane| pane.shell.as_ref())
+                        });
+                    let matches = match target {
+                        SidebarResource::Workspace { id, .. } => workspace_id == Some(id),
+                        SidebarResource::Shell { id, .. } => shell_id == Some(id),
+                        SidebarResource::Connection { .. } => false,
+                    };
+                    matches.then_some(*id)
+                })
+                .collect::<Vec<_>>();
         for id in &pane_ids {
             if let Some(pane) = self.terminals.remove(id) {
                 for image in pane.render_images.into_values() {
@@ -6699,6 +6720,30 @@ impl Workspace {
                         .child("REMOTE MACHINES"),
                 )
                 .children(rows)
+                .when(
+                    !self.layout_document.hidden_remote_workspaces.is_empty(),
+                    |panel| {
+                        panel
+                            .child(div().text_sm().child("HIDDEN WORKSPACES"))
+                            .children(self.layout_document.hidden_remote_workspaces.iter().map(
+                                |(id, name)| {
+                                    let id = id.clone();
+                                    Self::settings_option(
+                                        SharedString::from(format!("show-{id}")),
+                                        &format!("Show {name}"),
+                                        false,
+                                    )
+                                    .flex_none()
+                                    .on_click(cx.listener(
+                                        move |this, _, _, cx| {
+                                            cx.stop_propagation();
+                                            this.show_remote_workspace(&id, cx);
+                                        },
+                                    ))
+                                },
+                            ))
+                    },
+                )
                 .into_any_element(),
         )
     }
@@ -7801,6 +7846,12 @@ impl Workspace {
             SidebarResource::Workspace { id, .. } => Some(id.clone()),
             SidebarResource::Shell { .. } | SidebarResource::Connection { .. } => None,
         };
+        let hide_target = match &target {
+            SidebarResource::Workspace { id, .. } if remote::identity(id).is_some() => {
+                Some(target.clone())
+            }
+            _ => None,
+        };
         let rename_target = target.clone();
         let remove_target = target.clone();
 
@@ -7880,6 +7931,16 @@ impl Workspace {
                         .child("Rename")
                         .child(div().text_xs().text_color(rgb(0x6c7086)).child("F2")),
                 )
+                .when_some(hide_target, |element, target| {
+                    element.child(
+                        sidebar_menu_row("sidebar-menu-hide-workspace")
+                            .child("Hide from sidebar")
+                            .on_click(cx.listener(move |this, _, window, cx| {
+                                cx.stop_propagation();
+                                this.hide_remote_workspace(target.clone(), window, cx);
+                            })),
+                    )
+                })
                 .child(
                     div()
                         .id("sidebar-menu-remove")
@@ -8973,8 +9034,9 @@ impl Workspace {
                     .find(|workspace| workspace.id == *id)
                     .map_or(0, |workspace| workspace.shells.len());
                 format!(
-                    "This permanently removes “{name}” and its {shell_count} Boomux shell{}.",
-                    if shell_count == 1 { "" } else { "s" }
+                    "This permanently removes “{name}” and its {shell_count} Boomux shell{}.{}",
+                    if shell_count == 1 { "" } else { "s" },
+                    if remote::identity(id).is_some() { " The remote machine must be reachable. To remove only this sidebar entry, cancel and choose Hide from sidebar in its menu." } else { "" }
                 )
             }
         };

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -6730,7 +6730,7 @@ impl Workspace {
                                     let id = id.clone();
                                     Self::settings_option(
                                         SharedString::from(format!("show-{id}")),
-                                        &format!("Show {name}"),
+                                        format!("Show {name}"),
                                         false,
                                     )
                                     .flex_none()

--- a/desktop/src/remote_visibility.rs
+++ b/desktop/src/remote_visibility.rs
@@ -1,0 +1,150 @@
+//! Local sidebar preferences; never contacts a remote owner or deletes its work.
+use super::*;
+use std::collections::BTreeMap;
+
+pub fn filter(overview: &mut BoomuxOverview, hidden: &BTreeMap<String, String>) {
+    if hidden.is_empty() {
+        return;
+    }
+    let shells: HashSet<_> = overview
+        .workspaces
+        .iter()
+        .filter(|workspace| hidden.contains_key(&workspace.id))
+        .flat_map(|workspace| workspace.shells.iter().map(|shell| shell.id.clone()))
+        .collect();
+    overview
+        .workspaces
+        .retain(|workspace| !hidden.contains_key(&workspace.id));
+    overview
+        .agents
+        .retain(|agent| !shells.contains(&agent.shell_id));
+    if overview
+        .focused_shell_id
+        .as_ref()
+        .is_some_and(|id| shells.contains(id))
+    {
+        overview.focused_shell_id = None;
+    }
+}
+
+impl Workspace {
+    pub(super) fn hide_remote_workspace(
+        &mut self,
+        target: SidebarResource,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let SidebarResource::Workspace { id, name } = &target else {
+            return;
+        };
+        if remote::identity(id).is_none() {
+            return;
+        }
+        if self.layout_frozen || self.layout_restoring || self.layout_writer.is_none() {
+            self.boomux_error = Some(
+                "Sidebar preferences cannot be saved right now; reopen Desktop and retry.".into(),
+            );
+            cx.notify();
+            return;
+        }
+        if self.layout_document.hidden_remote_workspaces.len() >= 256 {
+            self.boomux_error = Some(
+                "Hidden Workspace limit reached. Show an entry from Remotes before hiding another."
+                    .into(),
+            );
+            cx.notify();
+            return;
+        }
+        self.layout_document
+            .hidden_remote_workspaces
+            .insert(id.clone(), name.clone());
+        self.remove_resource_panes(&target, window);
+        for saved in self.layout_document.arrangements.values_mut() {
+            saved
+                .panes
+                .retain(|_, pane| pane.workspace.as_ref() != Some(id));
+            saved.discard_unbound_panes();
+        }
+        self.layout_document
+            .arrangements
+            .remove(&format!("workspace:{id}"));
+        self.expanded_workspaces.remove(id);
+        self.sidebar_menu = None;
+        let overview = self.boomux_overview.clone();
+        self.set_boomux_overview(overview);
+        self.reconcile_sidebar_item();
+        self.save_remote_visibility(cx);
+        cx.notify();
+    }
+
+    pub(super) fn show_remote_workspace(&mut self, id: &str, cx: &mut Context<Self>) {
+        if self.layout_frozen || self.layout_restoring || self.layout_writer.is_none() {
+            return;
+        }
+        self.layout_document.hidden_remote_workspaces.remove(id);
+        self.save_remote_visibility(cx);
+        // The normal local-daemon snapshot refresh restores the cached entry.
+        cx.notify();
+    }
+
+    fn save_remote_visibility(&mut self, cx: &mut Context<Self>) {
+        self.capture_arrangement();
+        let Some(writer) = &self.layout_writer else {
+            return;
+        };
+        let pending = layout_state::submit(writer, self.layout_document.clone());
+        cx.spawn(async move |this, cx| {
+            if let Ok(result) = pending.recv().await {
+                let _ = this.update(cx, |this, cx| {
+                    this.layout_error = result.err();
+                    cx.notify();
+                });
+            }
+        })
+        .detach();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn hiding_remote_workspace_preserves_other_owners_and_can_be_reversed() {
+        let make_workspace = |id: &str, shell_id: &str| terminal::WorkspaceChoice {
+            id: id.into(),
+            name: "same-name".into(),
+            agent_count: 0,
+            shells: vec![ShellChoice {
+                id: shell_id.into(),
+                name: "shell".into(),
+                workspace_id: id.into(),
+                cwd: PathBuf::from("/tmp"),
+                status: boomux::protocol::ShellStatus::Pending,
+                run_id: None,
+                desktop_setup: false,
+            }],
+        };
+        let original = BoomuxOverview {
+            workspaces: vec![
+                make_workspace("remote:node-a:w", "remote:node-a:s"),
+                make_workspace("remote:node-b:w", "remote:node-b:s"),
+                make_workspace("w", "s"),
+            ],
+            agents: vec![],
+            focused_shell_id: Some("remote:node-a:s".into()),
+        };
+        let mut hidden = BTreeMap::from([("remote:node-a:w".into(), "same-name".into())]);
+        let mut overview = original.clone();
+        filter(&mut overview, &hidden);
+        assert_eq!(overview.workspaces.len(), 2);
+        assert_eq!(overview.workspaces[0].id, "remote:node-b:w");
+        assert_eq!(overview.workspaces[1].id, "w");
+        assert!(overview.focused_shell_id.is_none());
+        hidden.clear();
+        let mut overview = original.clone();
+        filter(&mut overview, &hidden);
+        assert_eq!(overview, original);
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,6 +28,7 @@ This is the implementation reference. For product usage, see the
 | `src/node_projection.rs` | Disposable owner-only remote projection cache, deterministic bounds, health, generation CAS, quarantine, and atomic storage |
 | `src/federation.rs` | Independently versioned federation handshake and verified stdio daemon bridging |
 | `src/ssh_bootstrap.rs` | Validated SSH targets, private invocation configuration, bounded interactive authentication presentation, deadline-bound remote discovery, and helper compatibility selection |
+| `src/remote_maintenance.rs` | Temporary owner-side repair/removal, existing-identity verification, user installation records, and retryable recovery serialization |
 | `src/handoff.rs`, `src/fd_transfer.rs` | Graceful daemon replacement records and Unix descriptor transfer |
 | `src/attach.rs` | Terminal-side raw mode, control frames, live input/output, resize, focus, takeover waiting, and reconnect handling |
 | `src/terminal.rs` | Selection and launch of native terminal windows through `xdg-terminal-exec` |

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -531,3 +531,18 @@ Shell creation, restart, or attachment takeover. Updates freeze saving and await
 the durable snapshot before launching the replacement; failure permits retry.
 A per-file lock plus revision comparison prevents stale windows from replacing
 newer state. Outer OS window placement remains outside this feature.
+
+## Remote Workspace visibility
+
+`src/remote_visibility.rs` filters owner-qualified remote Workspace keys from
+Desktop's overview before sidebar ordering and navigation. Hiding detaches open
+and restored panes and removes their saved arrangements; it does not mutate the
+owner or its projection cache. The normal local snapshot refresh restores shown
+entries. The hidden map is bounded to 256 entries with 1,024-byte identities and
+labels, and shares the existing bounded atomic layout writer and stale-writer
+revision checks.
+
+Desktop layout document version 2 adds `hidden_remote_workspaces`. Version 1 is
+explicitly migrated with an empty hidden map while preserving its revision and
+arrangements. Unknown versions remain rejected. This is separate from daemon
+persistence and wire versions, which are unchanged.

--- a/docs/lifecycle-validation.md
+++ b/docs/lifecycle-validation.md
@@ -468,3 +468,26 @@ cargo clippy --all-targets --all-features -- -D warnings
 Reducer tests remain compatibility evidence, not substitutes for the live cases
 listed above. Future host-version bumps should append a dated record rather than
 silently reusing this one.
+
+
+## 2026-09-11: Isolated Linux Remote Maintenance Recovery
+
+The development binary at version 1.18.0/protocol 54 was exercised in isolated
+HOME, state, config, and runtime directories. These are local native-process
+fixtures, not validation against a deployed remote host or macOS.
+
+- Repaired a missing executable while retaining the existing Node identity and
+  saved data; repeated uninstall succeeded with no executable left to remove.
+- Updated a running owner at a custom user installation path, then repaired the
+  same owner after unlinking its executable. The Shell run identity and actual
+  process survived both executable handoffs. Removal stopped that owner.
+- Rejected changed identity, changed executable, unsafe directory links, and
+  incompatible saved state before executable replacement. Removal preserved
+  incompatible saved state instead of requiring it to load.
+- Kept a legacy update transaction intact, rejected a held recovery lock, and
+  reclaimed an abandoned recovery lock.
+
+Focused fixtures separately exercise integration cleanup failures, unfamiliar
+integration names, local forget during maintenance, failed forget persistence,
+rollback with a copied backup, and expiration of staged recovery helpers. These
+checks do not establish live mixed-version protocol-52 or macOS recovery support.

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -266,8 +266,10 @@ NODE` verifies the pinned identity and, after
 confirmation, transactionally replaces a compatible registered helper without
 changing the registration. Immediately before activation it acquires a bounded
 local maintenance lease, drains admitted operations, and prevents rename,
-retarget, forget, projection, and routed operations until remote commit or
-rollback completes. The lease expires fail-open if the upgrading client dies.
+retarget, projection, and routed operations until remote commit or
+rollback completes. Local `node forget` can remove the registration during
+maintenance; it neither contacts the owner nor cancels an already-authorized
+remote operation. The lease expires fail-open if the upgrading client dies.
 
 The CLI renews it during a live transaction; local daemon restart and stop are
 busy while it remains active so handoff cannot silently reopen admission.
@@ -277,11 +279,13 @@ rollback whose completion cannot be confirmed leaves it closed until bounded
 expiry so the remote watchdog settles before local routing resumes.
 
 Human-only `node uninstall NODE` uses the same admission-closing maintenance
-lease after explicit process and data-impact confirmation. It requires an
-existing protocol-48 helper at the canonical user install destination, proves a
-present daemon executes that exact destination, performs Node-ID-conditional
-normal daemon stop, and owner-validates the regular single-link executable
-against its pre-confirmation fingerprint before removal. Remote state, config, modified
+lease after explicit process and data-impact confirmation. The normal path uses
+an existing protocol-48 helper at the canonical user install destination. If
+that helper is missing or runs from a different user installation, a temporary
+recovery helper inspects the existing Node identity and installation instead.
+Both paths identify a present daemon, perform Node-ID-conditional normal daemon
+stop, and revalidate the executable before removal. Already-missing executables
+are a successful removal condition after identity verification. Remote state, config, modified
 integrations, and the Agent Skill remain. Confirmed removal atomically deletes
 the local registration while admission is still closed, then best-effort removes
 its now-inaccessible disposable projection. Any failure retains the registration
@@ -553,8 +557,9 @@ Forget and retarget use prepare, drain, and commit phases. Prepare closes
 admission without changing the revision, then releases the mutation gate.
 Already admitted operations retain their reservation and can finish against the
 old registration. If the bounded drain cannot reach a completed or explicit
-unknown-outcome boundary, the operation reopens admission and returns `busy`
-without changing the route, revision, or tombstone epoch. After a successful
+unknown-outcome boundary, the operation restores admission to its previous
+maintenance-constrained state and returns `busy` without changing the route,
+revision, or tombstone epoch. After a successful
 drain, commit revalidates the unchanged registration under the gate, advances its
 revision or tombstone epoch, and removes the old cache. Retarget then installs the
 verified new route with admission closed until a fresh baseline succeeds. It
@@ -1093,13 +1098,46 @@ The initial contract excludes:
 - Treating a local daemon stop, restart, or Node removal as remote process
   authority.
 
-### Missing executable during an update
+### Repairing a missing or moved executable
 
-If a registered owner's executable has been removed, Update remote reports
-`install_required`. Missing executables are not evidence of pre-protocol-47
-state and do not require a state reset. Reinstall the standalone CLI on the
-owner using the [release installer](install.md), then retry. Existing pinned
-identity checks still apply; an update cannot silently adopt a different Node.
+**Update remote** (`node upgrade NODE`) can use a privately uploaded, temporary
+helper when the installed CLI is missing or a compatible helper is found at a
+noncanonical path. It reads the saved Node identity without creating a new
+identity or starting a daemon. A running owner supplies its kernel-verified
+executable path; otherwise recovery uses its owner-only installation record,
+then defaults to `~/.local/bin/boomux` when no record exists. Package-managed and
+Desktop-bundled executables remain owned by their installers.
+
+The confirmation displays the actual installation path. Repair validates
+readable saved state before a cold start and requires protocol 52 or newer for
+handoff from a running daemon. Existing binaries use a rollback transaction;
+missing binaries use atomic no-replace installation. A handoff is successful
+only after the running executable matches the installed inode and content.
+Recovery never resets saved state to bypass an incompatibility. Protocol-46
+owners still require the documented cold upgrade.
+
+Recovery records the verified path in `installation.json` beside `node.json`.
+This separate version-1 record contains only the Node identity and absolute
+installation path; it is bounded to 8 KiB, owner-only, and atomically replaced.
+A verified running daemon takes precedence over a stale record. This adds no
+registration, daemon-state, or wire-schema fields.
+
+Recovery operations serialize using a kernel lock on a regular
+`~/.local/bin/.boomux.bootstrap.lock` file. This also excludes legacy installers
+that acquire a directory at that path. A later recovery can reclaim a file lock
+after its process dies; it never deletes a legacy transaction directory. One
+reserved candidate and one rollback copy bound local recovery artifacts and
+avoid leaving the installed executable hard-linked after interruption.
+Temporary uploaded helpers are removed when the SSH session closes. A later
+preparation prunes abandoned helpers older than ten minutes and refuses staging
+when two helpers remain. Long-delayed confirmations may need fresh preparation.
+
+**Remove machine & uninstall Boomux** also uses recovery for missing executables.
+It preserves durable state and modified, unavailable, or unrecognized integration
+assets. Failed optional integration cleanup does not prevent verified executable
+removal. An unavailable owner still cannot be uninstalled remotely; **Forget
+connection only** always remains a local operation, including during an update's
+maintenance lease. Forgetting does not claim that remote software was removed.
 
 ### Hiding an unavailable Workspace in Desktop
 
@@ -1122,5 +1160,6 @@ be presented as an unknown upgrade outcome. Wait for cleanup before retrying.
 
 An ambiguous update failure can retain a separate local Node maintenance lease
 for up to ten minutes after its last renewal. This is distinct from the remote
-cleanup window. Registration changes and new update/uninstall attempts report
-the remaining local lease time and resume after expiry.
+cleanup window. Rename, retarget, and new update/uninstall attempts report
+the remaining local lease time and resume after expiry. Local forget remains
+available during this lease.

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1119,3 +1119,8 @@ up to three minutes while watchdog cleanup finishes. Another update during
 that window returns `busy` before uploading or replacing anything. This explicit
 refusal releases the attempted update's local maintenance window; it must not
 be presented as an unknown upgrade outcome. Wait for cleanup before retrying.
+
+An ambiguous update failure can retain a separate local Node maintenance lease
+for up to ten minutes after its last renewal. This is distinct from the remote
+cleanup window. Registration changes and new update/uninstall attempts report
+the remaining local lease time and resume after expiry.

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -123,6 +123,19 @@ existing batch observer without starting an overlapping worker or changing
 remote authority. Daemon protocol 38 or newer is required for that explicit
 observer wake.
 
+Sign-in first connects to SSH with one attempt and a 15-second connection/key
+exchange timeout (or the shorter operation budget). Interactive prompts retain
+up to two minutes. The terminal shows when SSH sign-in succeeds, when the pinned
+Boomux identity is checked, and when prompt-free background access is checked.
+Each subsequent verification operation has a 30-second budget. DNS, proxy
+commands, and interactive authentication remain subject to the outer operation
+budget. Network timeouts report reachability guidance rather than implying a
+password prompt is waiting. Press Ctrl+C to cancel the sign-in attempt.
+
+The connection deadline uses OpenSSH's
+[`ConnectTimeout`](https://man.openbsd.org/ssh_config#ConnectTimeout); it does not
+shorten the time available to answer interactive authentication prompts.
+
 ### Prepared Operations And Recovery
 
 Prepared operations are isolated and serialized by operation UUID, so concurrent
@@ -1079,3 +1092,24 @@ The initial contract excludes:
 - Remote TCP control listeners or forwarding the local daemon socket.
 - Treating a local daemon stop, restart, or Node removal as remote process
   authority.
+
+### Missing executable during an update
+
+If a registered owner's executable has been removed, Update remote reports
+`install_required`. Missing executables are not evidence of pre-protocol-47
+state and do not require a state reset. Reinstall the standalone CLI on the
+owner using the [release installer](install.md), then retry. Existing pinned
+identity checks still apply; an update cannot silently adopt a different Node.
+
+### Hiding an unavailable Workspace in Desktop
+
+A remote Workspace's three-dot menu offers **Hide from sidebar**. This changes
+only this Desktop's saved presentation and detaches its open panes. It works
+without contacting the owner and does not stop processes, delete Workspace
+state, or forget the machine. In **Remotes → Hidden Workspaces**, select
+**Show** to restore an entry from the normal cached overview refresh.
+
+**Remove** still deletes the Workspace and its Shells on the remote owner and
+requires connectivity. **Forget connection only** on the machine card removes
+all that machine's cached entries and its local registration without contacting
+the owner. These operations have distinct scopes.

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1113,3 +1113,9 @@ state, or forget the machine. In **Remotes → Hidden Workspaces**, select
 requires connectivity. **Forget connection only** on the machine card removes
 all that machine's cached entries and its local registration without contacting
 the owner. These operations have distinct scopes.
+
+A completed remote update retains its transaction lock and rollback files for
+up to three minutes while watchdog cleanup finishes. Another update during
+that window returns `busy` before uploading or replacing anything. This explicit
+refusal releases the attempted update's local maintenance window; it must not
+be presented as an unknown upgrade outcome. Wait for cleanup before retrying.

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -154,6 +154,24 @@ pub fn run_stdio_helper() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+/// Inspect existing identity for recovery without creating a Node or daemon.
+#[doc(hidden)]
+pub fn existing_node_identity() -> std::io::Result<String> {
+    Ok(
+        crate::node_identity::NodeIdentity::load_existing_from_environment()?
+            .id()
+            .to_owned(),
+    )
+}
+
+/// Validate saved state without migrating or starting the owner.
+#[doc(hidden)]
+pub fn validate_recovery_state() -> std::io::Result<()> {
+    crate::state_store::StateStore::from_environment()?
+        .load_deferred()
+        .map(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2423,6 +2423,7 @@ fn uninstall_node(selector: &str) -> Result<(), Box<dyn Error>> {
 
 fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
     const TIMEOUT: Duration = Duration::from_secs(120);
+    const VERIFY_TIMEOUT: Duration = Duration::from_secs(30);
 
     if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
         return Err(io::Error::new(
@@ -2442,7 +2443,7 @@ fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
     println!("Node: {} ({})", registration.alias, registration.node_id);
     println!("Stored SSH route: {}", registration.target);
     println!(
-        "Complete any SSH authentication prompt or login URL shown in this terminal. Boomux will not install, upgrade, retarget, or modify the registration."
+        "Connecting to the remote machine (15-second SSH connection timeout). Sign-in prompts or a login URL will appear here if required; allow up to 2 minutes to complete sign-in. Press Ctrl+C to cancel."
     );
     io::Write::flush(&mut io::stdout())?;
 
@@ -2453,21 +2454,25 @@ fn reauthenticate_node(selector: &str) -> Result<(), Box<dyn Error>> {
         TIMEOUT,
     )
     .map_err(bootstrap_cli_failure)?;
+    println!("SSH sign-in succeeded. Checking the remote Boomux identity (up to 30 seconds)...");
+    io::Write::flush(&mut io::stdout())?;
     let connection = session
-        .connect_existing_verified(&registration.node_id, TIMEOUT)
+        .connect_existing_verified(&registration.node_id, VERIFY_TIMEOUT)
         .map_err(bootstrap_cli_failure)?;
     drop(connection);
 
-    println!("Verifying that background observation can reconnect without prompts...");
+    println!(
+        "Remote identity verified. Checking background access without prompts (up to 30 seconds per check)..."
+    );
     io::Write::flush(&mut io::stdout())?;
     let session = ssh_bootstrap::BootstrapSession::open(
         target,
         ssh_bootstrap::SshAuthenticationMode::Batch,
-        TIMEOUT,
+        VERIFY_TIMEOUT,
     )
     .map_err(bootstrap_cli_failure)?;
     let connection = session
-        .connect_existing_verified(&registration.node_id, TIMEOUT)
+        .connect_existing_verified(&registration.node_id, VERIFY_TIMEOUT)
         .map_err(bootstrap_cli_failure)?;
 
     let current = local.node_registration(&registration.node_id)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ mod macos_terminal;
 mod mobile_web;
 mod process_adapter;
 mod projects;
+mod remote_maintenance;
 mod session_projection;
 mod setup;
 mod tailscale_serve;
@@ -499,6 +500,12 @@ enum Commands {
     },
     #[command(name = "__uninstall-fingerprint", hide = true)]
     UninstallFingerprint,
+    #[command(name = "__remote-maintenance", hide = true)]
+    RemoteMaintenance {
+        action: String,
+        expected_node_id: String,
+        token: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1378,6 +1385,7 @@ command_keys! {
     ResumeSessionInternal => ("resume-session-internal", HumanOnly),
     UninstallRemote => ("uninstall-remote", HumanOnly),
     UninstallFingerprint => ("uninstall-fingerprint", HumanOnly),
+    RemoteMaintenance => ("remote-maintenance", HumanOnly),
 }
 
 impl Cli {
@@ -1647,6 +1655,7 @@ impl Cli {
             Some(Commands::GuidedNodeReauthenticate { .. }) => CommandKey::NodeReauthenticate,
             Some(Commands::UninstallRemote { .. }) => CommandKey::UninstallRemote,
             Some(Commands::UninstallFingerprint) => CommandKey::UninstallFingerprint,
+            Some(Commands::RemoteMaintenance { .. }) => CommandKey::RemoteMaintenance,
             Some(Commands::BootstrapActivate { .. }) => CommandKey::Daemon,
         }
     }
@@ -2109,6 +2118,11 @@ fn run(cli: Cli) -> Result<CliExit, Box<dyn Error>> {
             expected_node_id,
             expected_executable,
         }) => uninstall::remote_uninstall(&expected_node_id, &expected_executable),
+        Some(Commands::RemoteMaintenance {
+            action,
+            expected_node_id,
+            token,
+        }) => remote_maintenance::run(&action, &expected_node_id, token.as_deref()),
         Some(Commands::UninstallFingerprint) => {
             let target = update::remote_uninstall_target()?;
             println!(
@@ -2263,9 +2277,15 @@ fn upgrade_node(selector: &str) -> Result<(), Box<dyn Error>> {
     println!("Remote target: {}", registration.target);
     println!("Install source: {}", plan.source.description());
     println!("Install destination: {}", plan.destination.as_str());
-    println!(
-        "Process impact: this workflow requires an already protocol-compatible helper; the pinned binary is uploaded privately first, activation requires proof that the running daemon uses this destination, the previous executable is retained for rollback, and any present compatible daemon is restarted"
-    );
+    if plan.uses_recovery_helper() {
+        println!(
+            "Process impact: a temporary recovery helper repairs the verified user installation and hands any compatible running daemon over to it. Saved Workspace data and Node identity are preserved."
+        );
+    } else {
+        println!(
+            "Process impact: the pinned binary is uploaded privately, the previous executable is retained for rollback, and any compatible running daemon is restarted after its installation is verified."
+        );
+    }
     if !confirm_setup("Upgrade Boomux on this registered Node?")? {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,

--- a/src/node_identity.rs
+++ b/src/node_identity.rs
@@ -36,6 +36,10 @@ pub(crate) struct NodeIdentityLease {
 }
 
 impl NodeIdentity {
+    pub(crate) fn load_existing_from_environment() -> io::Result<Self> {
+        load(&state_directory_from_environment()?.join("node.json"))
+    }
+
     pub(crate) fn load_or_create_from_environment() -> io::Result<Self> {
         Self::load_or_create_at(state_directory_from_environment()?.join("node.json"))
     }

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -354,35 +354,41 @@ impl NodeRegistrationManager {
     ) -> io::Result<NodeRegistrationSnapshot> {
         validate_target(&target)?;
         validate_node_id(verified_node_id)?;
-        self.prepare_drain_commit(selector, expected_revision, timeout, |state, index| {
-            if state.registrations[index].snapshot.node_id != verified_node_id {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    "new SSH target resolved to a different Boomux Node identity",
-                ));
-            }
-            if state.registrations[index].snapshot.target == target {
-                return Ok(state.registrations[index].snapshot.clone());
-            }
-            if state
-                .registrations
-                .iter()
-                .enumerate()
-                .any(|(other, registration)| {
-                    other != index && registration.snapshot.target == target
-                })
-            {
-                return Err(io::Error::new(
-                    io::ErrorKind::AlreadyExists,
-                    "SSH target is already registered",
-                ));
-            }
-            let revision = next(state.revision, "registration revision")?;
-            state.revision = revision;
-            state.registrations[index].snapshot.target = target;
-            state.registrations[index].snapshot.revision = revision;
-            Ok(state.registrations[index].snapshot.clone())
-        })
+        self.prepare_drain_commit(
+            selector,
+            expected_revision,
+            timeout,
+            false,
+            |state, index| {
+                if state.registrations[index].snapshot.node_id != verified_node_id {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "new SSH target resolved to a different Boomux Node identity",
+                    ));
+                }
+                if state.registrations[index].snapshot.target == target {
+                    return Ok(state.registrations[index].snapshot.clone());
+                }
+                if state
+                    .registrations
+                    .iter()
+                    .enumerate()
+                    .any(|(other, registration)| {
+                        other != index && registration.snapshot.target == target
+                    })
+                {
+                    return Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        "SSH target is already registered",
+                    ));
+                }
+                let revision = next(state.revision, "registration revision")?;
+                state.revision = revision;
+                state.registrations[index].snapshot.target = target;
+                state.registrations[index].snapshot.revision = revision;
+                Ok(state.registrations[index].snapshot.clone())
+            },
+        )
     }
 
     pub(crate) fn forget(
@@ -391,13 +397,19 @@ impl NodeRegistrationManager {
         timeout: Duration,
     ) -> io::Result<NodeRegistrationSnapshot> {
         let expected_revision = self.inspect(selector)?.revision;
-        self.prepare_drain_commit(selector, expected_revision, timeout, |state, index| {
-            let tombstone_epoch = next(state.tombstone_epoch, "registration tombstone epoch")?;
-            state.tombstone_epoch = tombstone_epoch;
-            let mut removed = state.registrations.remove(index).snapshot;
-            removed.tombstone_epoch = tombstone_epoch;
-            Ok(removed)
-        })
+        self.prepare_drain_commit(
+            selector,
+            expected_revision,
+            timeout,
+            true,
+            |state, index| {
+                let tombstone_epoch = next(state.tombstone_epoch, "registration tombstone epoch")?;
+                state.tombstone_epoch = tombstone_epoch;
+                let mut removed = state.registrations.remove(index).snapshot;
+                removed.tombstone_epoch = tombstone_epoch;
+                Ok(removed)
+            },
+        )
     }
 
     pub(crate) fn begin_upgrade_maintenance_if(
@@ -586,6 +598,7 @@ impl NodeRegistrationManager {
         selector: &str,
         expected_revision: u64,
         timeout: Duration,
+        forget_maintenance: bool,
         mutate: impl FnOnce(&mut RegistrationState, usize) -> io::Result<NodeRegistrationSnapshot>,
     ) -> io::Result<NodeRegistrationSnapshot> {
         let mut state = self.lock_state()?;
@@ -593,7 +606,9 @@ impl NodeRegistrationManager {
         expire_maintenance(current);
         let index = find_index(current, selector)?;
         require_revision(&current.registrations[index], expected_revision)?;
-        if !current.registrations[index].admission_open {
+        let bypass_maintenance =
+            forget_maintenance && current.registrations[index].maintenance.is_some();
+        if !current.registrations[index].admission_open && !bypass_maintenance {
             return Err(registration_busy(&current.registrations[index]));
         }
         current.registrations[index].admission_epoch = next(
@@ -610,7 +625,8 @@ impl NodeRegistrationManager {
                 break;
             }
             let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
-                current.registrations[index].admission_open = true;
+                current.registrations[index].admission_open =
+                    current.registrations[index].maintenance.is_none();
                 self.changed.notify_all();
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -625,7 +641,8 @@ impl NodeRegistrationManager {
             if wait.timed_out() {
                 let current = available_mut(&mut state)?;
                 let index = find_index(current, selector)?;
-                current.registrations[index].admission_open = true;
+                current.registrations[index].admission_open =
+                    current.registrations[index].maintenance.is_none();
                 self.changed.notify_all();
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -640,16 +657,22 @@ impl NodeRegistrationManager {
         let result = match mutate(&mut replacement, index) {
             Ok(result) => result,
             Err(error) => {
-                current.registrations[index].admission_open = true;
+                current.registrations[index].admission_open =
+                    current.registrations[index].maintenance.is_none();
                 self.changed.notify_all();
                 return Err(error);
             }
         };
-        if let Some(registration) = replacement.registrations.get_mut(index) {
-            registration.admission_open = true;
+        if let Some(registration) = replacement
+            .registrations
+            .iter_mut()
+            .find(|registration| registration.snapshot.node_id == result.node_id)
+        {
+            registration.admission_open = registration.maintenance.is_none();
         }
         if let Err(error) = save(&self.path, &replacement) {
-            current.registrations[index].admission_open = true;
+            current.registrations[index].admission_open =
+                current.registrations[index].maintenance.is_none();
             self.changed.notify_all();
             return Err(error);
         }
@@ -1275,6 +1298,70 @@ mod tests {
         assert!(manager.admit(&registration).unwrap());
         manager.release(&registration);
         fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn local_forget_does_not_wait_for_remote_maintenance() {
+        let path = path();
+        let manager = NodeRegistrationManager::load_at(path.clone());
+        let registration = manager
+            .add("work".into(), "offline".into(), node_id(2), &node_id(1))
+            .unwrap();
+        let (_, token) = manager
+            .begin_upgrade_maintenance_if(
+                "work",
+                registration.revision,
+                Duration::from_millis(1),
+                Duration::from_secs(60),
+                || true,
+            )
+            .unwrap();
+        manager.forget("work", Duration::from_millis(10)).unwrap();
+        assert!(manager.inspect("work").is_err());
+        assert!(!manager.has_active_upgrade_maintenance().unwrap());
+        assert!(
+            manager
+                .finish_upgrade_maintenance(&registration.node_id, &token)
+                .is_err()
+        );
+        assert!(
+            NodeRegistrationManager::load_at(path.clone())
+                .inspect("work")
+                .is_err()
+        );
+        fs::remove_dir_all(path.parent().unwrap().parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn failed_local_forget_preserves_the_maintenance_lease() {
+        let path = path();
+        let manager = NodeRegistrationManager::load_at(path.clone());
+        let registration = manager
+            .add("work".into(), "offline".into(), node_id(2), &node_id(1))
+            .unwrap();
+        let (_, token) = manager
+            .begin_upgrade_maintenance_if(
+                "work",
+                registration.revision,
+                Duration::from_millis(1),
+                Duration::from_secs(60),
+                || true,
+            )
+            .unwrap();
+        let parent = path.parent().unwrap();
+        let moved = parent.with_extension("saved");
+        fs::rename(parent, &moved).unwrap();
+        fs::write(parent, b"prevent persistence").unwrap();
+        assert!(manager.forget("work", Duration::from_millis(10)).is_err());
+        assert!(manager.has_active_upgrade_maintenance().unwrap());
+        assert!(!manager.admit(&registration).unwrap());
+        fs::remove_file(parent).unwrap();
+        fs::rename(&moved, parent).unwrap();
+        manager
+            .finish_upgrade_maintenance(&registration.node_id, &token)
+            .unwrap();
+        manager.forget("work", Duration::from_millis(10)).unwrap();
+        fs::remove_dir_all(parent.parent().unwrap()).unwrap();
     }
 
     #[test]

--- a/src/node_registration.rs
+++ b/src/node_registration.rs
@@ -420,10 +420,7 @@ impl NodeRegistrationManager {
         let index = find_index(current, selector)?;
         require_revision(&current.registrations[index], expected_revision)?;
         if !current.registrations[index].admission_open {
-            return Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "Node registration change is already in progress",
-            ));
+            return Err(registration_busy(&current.registrations[index]));
         }
         current.registrations[index].admission_epoch = next(
             current.registrations[index].admission_epoch,
@@ -597,10 +594,7 @@ impl NodeRegistrationManager {
         let index = find_index(current, selector)?;
         require_revision(&current.registrations[index], expected_revision)?;
         if !current.registrations[index].admission_open {
-            return Err(io::Error::new(
-                io::ErrorKind::WouldBlock,
-                "Node registration change is already in progress",
-            ));
+            return Err(registration_busy(&current.registrations[index]));
         }
         current.registrations[index].admission_epoch = next(
             current.registrations[index].admission_epoch,
@@ -714,6 +708,21 @@ fn available_mut(state: &mut ManagerState) -> io::Result<&mut RegistrationState>
             format!("Node registration routing is disabled: {reason}"),
         )),
     }
+}
+
+fn registration_busy(registration: &Registration) -> io::Error {
+    let message = match &registration.maintenance {
+        Some(lease) => {
+            let remaining = lease.deadline.saturating_duration_since(Instant::now());
+            let seconds = remaining.as_secs() + u64::from(remaining.subsec_nanos() != 0);
+            format!(
+                "This Node is reserved by an update or uninstall; its local maintenance lease expires in {seconds} seconds unless renewed. A failed update may retain this lease while remote recovery settles; wait and retry."
+            )
+        }
+        None => "Node registration change is already in progress; wait for it to finish and retry"
+            .into(),
+    };
+    io::Error::new(io::ErrorKind::WouldBlock, message)
 }
 
 fn expire_maintenance(state: &mut RegistrationState) {
@@ -1209,6 +1218,22 @@ mod tests {
         manager
             .renew_upgrade_maintenance(&registration.node_id, &token, Duration::from_secs(1))
             .unwrap();
+        let blocked = manager
+            .begin_upgrade_maintenance_if(
+                "work",
+                registration.revision,
+                Duration::from_secs(1),
+                Duration::from_secs(1),
+                || true,
+            )
+            .unwrap_err();
+        assert_eq!(blocked.kind(), io::ErrorKind::WouldBlock);
+        assert!(
+            blocked
+                .to_string()
+                .contains("local maintenance lease expires in")
+        );
+        assert!(blocked.to_string().contains("seconds unless renewed"));
         thread::sleep(Duration::from_millis(2));
         assert!(!manager.admit(&registration).unwrap());
         assert_eq!(

--- a/src/remote_maintenance.rs
+++ b/src/remote_maintenance.rs
@@ -1,0 +1,458 @@
+//! Temporary owner-side recovery for missing or noncanonical user installations.
+//! The runner is uploaded privately and never creates identity or deletes durable state.
+use crate::{
+    client, config,
+    integration_management::{self, AssetState, Environment, IntegrationId},
+    update,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    env, fs,
+    io::{self, Read, Write},
+    os::unix::fs::{MetadataExt, OpenOptionsExt},
+    path::{Path, PathBuf},
+};
+
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+const MAX_BINARY: u64 = 256 * 1024 * 1024;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Probe {
+    version: u32,
+    node_id: String,
+    destination: PathBuf,
+    installed: Option<String>,
+    daemon_pid: Option<u32>,
+    daemon_executable: Option<PathBuf>,
+    preserved: Vec<String>,
+}
+
+fn private_directory(path: &Path) -> io::Result<()> {
+    let m = fs::symlink_metadata(path)?;
+    if !m.is_dir()
+        || m.file_type().is_symlink()
+        || m.uid() != unsafe { libc::geteuid() }
+        || m.mode() & 0o022 != 0
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "maintenance directory is not privately owned",
+        ));
+    }
+    Ok(())
+}
+
+fn binary_token(path: &Path) -> io::Result<Option<String>> {
+    let mut f = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e),
+    };
+    let m = f.metadata()?;
+    if !m.is_file()
+        || m.uid() != unsafe { libc::geteuid() }
+        || m.mode() & 0o022 != 0
+        || m.nlink() != 1
+        || m.len() == 0
+        || m.len() > MAX_BINARY
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "maintenance executable is not an owned regular file",
+        ));
+    }
+    let mut hash = Sha256::new();
+    let mut bytes = [0; 64 * 1024];
+    let mut total = 0;
+    loop {
+        let n = f.read(&mut bytes)?;
+        if n == 0 {
+            break;
+        }
+        total += n as u64;
+        if total > MAX_BINARY {
+            return Err(io::Error::other("executable exceeds inspection limit"));
+        }
+        hash.update(&bytes[..n]);
+    }
+    let after = f.metadata()?;
+    if total != m.len()
+        || m.len() != after.len()
+        || m.mtime() != after.mtime()
+        || m.mtime_nsec() != after.mtime_nsec()
+        || m.ctime() != after.ctime()
+        || m.ctime_nsec() != after.ctime_nsec()
+        || m.mode() != after.mode()
+    {
+        return Err(io::Error::other("executable changed during inspection"));
+    }
+    Ok(Some(format!(
+        "{}:{}:{}:{:x}",
+        m.dev(),
+        m.ino(),
+        m.len(),
+        hash.finalize()
+    )))
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Installation {
+    version: u32,
+    node_id: String,
+    path: PathBuf,
+}
+
+fn receipt_path() -> Result<PathBuf> {
+    let home = PathBuf::from(env::var_os("HOME").ok_or("HOME missing")?);
+    let root = env::var_os("BOOMUX_STATE_HOME")
+        .or_else(|| env::var_os("XDG_STATE_HOME"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|| home.join(".local/state"));
+    Ok(root.join("boomux/installation.json"))
+}
+
+fn owned_destination(home: &Path, destination: &Path, create: bool) -> Result<()> {
+    if update::is_package_path(destination) {
+        return Err("package-managed executable; use its package manager".into());
+    }
+    let relative = destination
+        .strip_prefix(home)
+        .map_err(|_| "package-managed executable; use its package manager")?;
+    if relative
+        .components()
+        .any(|c| !matches!(c, std::path::Component::Normal(_)))
+        || relative.components().count() < 2
+    {
+        return Err("invalid user installation path".into());
+    }
+    if relative.starts_with(".local/share/boomux-desktop") || relative.starts_with("Applications") {
+        return Err(
+            "this executable belongs to a Desktop bundle; use its Desktop installer".into(),
+        );
+    }
+    private_directory(home)?;
+    let mut directory = home.to_path_buf();
+    let parent = relative.parent().ok_or("installation parent missing")?;
+    for part in parent.components() {
+        directory.push(part);
+        if !directory.try_exists()? {
+            if create {
+                use std::os::unix::fs::DirBuilderExt;
+                fs::DirBuilder::new().mode(0o700).create(&directory)?;
+            } else {
+                continue;
+            }
+        }
+        private_directory(&directory)?;
+    }
+    Ok(())
+}
+
+fn read_receipt(expected: &str) -> Result<Option<PathBuf>> {
+    let path = receipt_path()?;
+    let file = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+        .open(path)
+    {
+        Ok(file) => file,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o077 != 0
+        || metadata.len() > 8192
+    {
+        return Err("unsafe installation record".into());
+    }
+    let mut bytes = Vec::new();
+    file.take(8193).read_to_end(&mut bytes)?;
+    let receipt: Installation = serde_json::from_slice(&bytes)?;
+    if receipt.version != 1 || receipt.node_id != expected {
+        return Err("installation record belongs to another Node or version".into());
+    }
+    Ok(Some(receipt.path))
+}
+
+fn record_installation(probe: &Probe) -> Result<()> {
+    let path = receipt_path()?;
+    private_directory(path.parent().ok_or("receipt parent missing")?)?;
+    let temporary = path.with_file_name(".installation.next");
+    update::remove_recovery_temporary(&temporary)?;
+    let result = (|| -> Result<()> {
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)?;
+        file.write_all(&serde_json::to_vec(&Installation {
+            version: 1,
+            node_id: probe.node_id.clone(),
+            path: probe.destination.clone(),
+        })?)?;
+        file.sync_all()?;
+        fs::rename(&temporary, &path)?;
+        fs::File::open(path.parent().unwrap())?.sync_all()?;
+        Ok(())
+    })();
+    let _ = fs::remove_file(temporary);
+    result
+}
+
+fn probe(expected: &str) -> Result<Probe> {
+    let node_id = boomux::federation::existing_node_identity()?;
+    if node_id != expected {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "remote Node identity changed; refusing maintenance",
+        )
+        .into());
+    }
+    let home = PathBuf::from(env::var_os("HOME").ok_or("HOME is missing")?);
+    if !home.is_absolute() {
+        return Err("HOME must be absolute".into());
+    }
+    let mut destination = home.join(".local/bin/boomux");
+    let (daemon_pid, daemon_executable) = if let Some(daemon) = client::connect_if_running()? {
+        if daemon.node_identity()? != node_id {
+            return Err("running daemon belongs to another Node".into());
+        }
+        let executable = update::daemon_executable(&daemon)
+            .ok_or("running daemon executable cannot be verified")?;
+        destination = executable.path.clone();
+        (Some(executable.pid), Some(executable.path))
+    } else {
+        if let Some(recorded) = read_receipt(expected)? {
+            destination = recorded;
+        }
+        (None, None)
+    };
+    owned_destination(&home, &destination, false)?;
+    let installed = binary_token(&destination)?;
+    let environment = Environment::from_process();
+    let preserved = IntegrationId::all()
+        .into_iter()
+        .filter_map(|id| {
+            let status = integration_management::inspect(id, &environment, None);
+            matches!(
+                status.asset.state,
+                AssetState::Modified | AssetState::Unavailable
+            )
+            .then(|| id.spec().display_name.to_string())
+        })
+        .collect();
+    Ok(Probe {
+        version: 1,
+        node_id,
+        destination,
+        installed,
+        daemon_pid,
+        daemon_executable,
+        preserved,
+    })
+}
+
+fn token(probe: &Probe) -> Result<String> {
+    Ok(format!("{:x}", Sha256::digest(serde_json::to_vec(probe)?)))
+}
+
+struct RecoveryLock {
+    path: PathBuf,
+    file: fs::File,
+}
+impl RecoveryLock {
+    fn acquire(path: &Path) -> Result<Self> {
+        let mut file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(path)
+            .map_err(|_| "another update is finishing recovery; retry shortly")?;
+        use std::os::fd::AsRawFd;
+        let m = file.metadata()?;
+        if !m.is_file()
+            || m.uid() != unsafe { libc::geteuid() }
+            || m.mode() & 0o077 != 0
+            || m.nlink() != 1
+            || m.len() > 64
+        {
+            return Err("unsafe maintenance lock".into());
+        }
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            return Err("another recovery operation is active; retry shortly".into());
+        }
+        let mut contents = String::new();
+        Read::by_ref(&mut file)
+            .take(65)
+            .read_to_string(&mut contents)?;
+        if !contents.is_empty() && contents != "boomux-recovery-v1\n" {
+            return Err("unrecognized maintenance lock".into());
+        }
+        if contents.is_empty() {
+            file.write_all(b"boomux-recovery-v1\n")?;
+            file.sync_all()?;
+        }
+        let current = fs::symlink_metadata(path)?;
+        if current.dev() != m.dev() || current.ino() != m.ino() {
+            return Err("maintenance lock changed; retry".into());
+        }
+        Ok(Self {
+            path: path.into(),
+            file,
+        })
+    }
+}
+impl Drop for RecoveryLock {
+    fn drop(&mut self) {
+        if let (Ok(current), Ok(held)) = (fs::symlink_metadata(&self.path), self.file.metadata())
+            && current.dev() == held.dev()
+            && current.ino() == held.ino()
+        {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub(crate) fn run(action: &str, expected: &str, authorization: Option<&str>) -> Result<()> {
+    let initial = probe(expected)?;
+    if action == "probe" {
+        println!(
+            "{}",
+            serde_json::json!({"probe": initial, "token":token(&initial)?})
+        );
+        return Ok(());
+    }
+    if !matches!(action, "repair" | "remove") {
+        return Err("unknown maintenance action".into());
+    }
+    if authorization != Some(token(&initial)?.as_str()) {
+        return Err("installation changed after maintenance preparation; retry".into());
+    }
+    boomux::ssh_bootstrap::secure_runtime_directory(
+        client::socket_path()?
+            .parent()
+            .ok_or("runtime parent missing")?,
+    )?;
+    // A regular file blocks legacy installers' mkdir lock too. Kernel flock
+    // lets a new recovery runner reclaim this file after an interrupted run.
+    let home = PathBuf::from(env::var_os("HOME").ok_or("HOME missing")?);
+    let canonical = home.join(".local/bin/boomux");
+    owned_destination(&home, &canonical, true)?;
+    let _lock = RecoveryLock::acquire(&canonical.with_file_name(".boomux.bootstrap.lock"))?;
+    let current = probe(expected)?;
+    if token(&current)? != token(&initial)? {
+        return Err("installation changed during maintenance preparation; retry".into());
+    }
+    if action == "repair" {
+        let notifications = config::load_notification_settings().map_err(
+            |_| "remote configuration could not be read; repair it on the owner before updating",
+        )?;
+        let _absence = if initial.daemon_pid.is_none() {
+            Some(update::reserve_daemon_absence(&client::socket_path()?)?)
+        } else {
+            None
+        };
+        if initial.daemon_pid.is_some()
+            && !client::connect()?.supports(boomux::protocol::ProtocolFeature::RestartExecutable)?
+        {
+            return Err("running daemon predates safe executable handoff; repair requires protocol 52 or newer".into());
+        }
+        if initial.daemon_pid.is_none() {
+            boomux::federation::validate_recovery_state()
+                .map_err(|_| "saved remote state cannot be read by this Boomux version; use a compatible release")?;
+        }
+        let home = PathBuf::from(env::var_os("HOME").ok_or("HOME missing")?);
+        owned_destination(&home, &initial.destination, true)?;
+        record_installation(&initial)?;
+        let source = env::current_exe()?;
+        binary_token(&source)?.ok_or("recovery runner disappeared")?;
+        let mut input = fs::File::open(source)?;
+        let temporary = initial.destination.with_file_name(".boomux-repair-install");
+        update::remove_recovery_temporary(&temporary)?;
+        let result = (|| -> Result<()> {
+            let mut output = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o700)
+                .open(&temporary)?;
+            if io::copy(&mut (&mut input).take(MAX_BINARY + 1), &mut output)? > MAX_BINARY {
+                return Err("executable exceeds inspection limit".into());
+            }
+            output.sync_all()?;
+            drop(output);
+            // Revalidate the target and never overwrite a concurrent first install.
+            if binary_token(&initial.destination)? != initial.installed {
+                return Err("installation changed before replacement".into());
+            }
+            if initial.installed.is_some() {
+                update::replace_for_recovery(
+                    &initial.destination,
+                    &temporary,
+                    expected,
+                    notifications.clone().into(),
+                    initial.daemon_pid.is_some(),
+                )?;
+            } else {
+                update::rename_noreplace(&temporary, &initial.destination)?;
+            }
+            Ok(())
+        })();
+        let _ = fs::remove_file(&temporary);
+        result?;
+        fs::File::open(initial.destination.parent().unwrap())?.sync_all()?;
+        if initial.installed.is_none() && initial.daemon_pid.is_some() {
+            let daemon = client::connect()?;
+            if daemon.node_identity()? != expected {
+                return Err("Node identity changed before handoff".into());
+            }
+            daemon.restart_with_executable(initial.destination.clone(), notifications.into())?;
+            update::verify_recovery_executable(&daemon, &initial.destination)?;
+        }
+        println!("Repaired Boomux at {}", initial.destination.display());
+    } else {
+        let environment = Environment::from_process();
+        crate::uninstall::stop_web_gateways()?;
+        if initial.daemon_pid.is_some() {
+            client::connect()?.shutdown_if_node_identity(expected)?;
+        }
+        let _reservation = update::reserve_daemon_absence(&client::socket_path()?)?;
+        for id in IntegrationId::all() {
+            let status = integration_management::inspect(id, &environment, None);
+            if status.asset.state == AssetState::Current
+                && let Err(error) = integration_management::uninstall(id, &environment, false)
+            {
+                eprintln!("Preserved {} integration: {error}", id.spec().display_name);
+            }
+        }
+        if binary_token(&initial.destination)? != initial.installed {
+            return Err("executable changed during removal; retry".into());
+        }
+        if initial.installed.is_some() {
+            fs::remove_file(&initial.destination)?;
+        }
+        if initial.destination.parent().unwrap().exists() {
+            fs::File::open(initial.destination.parent().unwrap())?.sync_all()?;
+        }
+        let _ = fs::remove_file(receipt_path()?);
+        for name in [".boomux-repair-install", ".boomux-recovery-backup"] {
+            if update::remove_recovery_temporary(&initial.destination.with_file_name(name)).is_err()
+            {
+                eprintln!("Preserved an unrecognized recovery artifact");
+            }
+        }
+        println!("Removed Boomux; saved Workspace data preserved");
+    }
+    Ok(())
+}

--- a/src/remote_maintenance.rs
+++ b/src/remote_maintenance.rs
@@ -240,7 +240,6 @@ fn probe(expected: &str) -> Result<Probe> {
     let installed = binary_token(&destination)?;
     let environment = Environment::from_process();
     let preserved = IntegrationId::all()
-        .into_iter()
         .filter_map(|id| {
             let status = integration_management::inspect(id, &environment, None);
             matches!(

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -176,7 +176,7 @@ const REMOTE_INSTALL_RENEW_COMMAND: &str = concat!(
 );
 
 pub const PLATFORM_PROBE_COMMAND: &str = "os=$(/usr/bin/uname -s) || exit 92; arch=$(/usr/bin/uname -m) || exit 92; case \"$os\" in Linux|Darwin) ;; *) exit 92 ;; esac; for command in /usr/bin/uname /usr/bin/id /usr/bin/stat /usr/bin/cmp /bin/cat /bin/chmod /bin/cp /bin/date /bin/kill /bin/ln /bin/mkdir /bin/mv /bin/ps /bin/rm /bin/rmdir /bin/sleep /bin/sync; do [ -x \"$command\" ] || exit 92; done; printf 'boomux-platform-v1\\0%s\\0%s\\0' \"$os\" \"$arch\"";
-pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) if [ \"$candidate\" = \"$HOME/.local/bin/boomux\" ] && [ -d \"$HOME/.local/bin/.boomux.bootstrap.lock\" ] && [ ! -d \"$HOME/.local/bin/.boomux.bootstrap.lock/committed\" ]; then continue; fi; [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done; true";
+pub const EXECUTABLE_PROBE_COMMAND: &str = "printf 'boomux-executables-v1\\0'; path=$(command -v boomux 2>/dev/null || true); for candidate in \"$path\" /usr/local/bin/boomux /usr/bin/boomux /opt/homebrew/bin/boomux \"$HOME/.cargo/bin/boomux\" /home/linuxbrew/.linuxbrew/bin/boomux \"$HOME/.local/bin/boomux\" \"$HOME/.local/share/mise/shims/boomux\" \"$HOME/.nix-profile/bin/boomux\" /run/current-system/sw/bin/boomux; do case \"$candidate\" in /*) if [ \"$candidate\" = \"$HOME/.local/bin/boomux\" ] && [ -e \"$HOME/.local/bin/.boomux.bootstrap.lock\" ] && [ ! -d \"$HOME/.local/bin/.boomux.bootstrap.lock/committed\" ]; then continue; fi; [ -f \"$candidate\" ] && [ -x \"$candidate\" ] && printf '%s\\0' \"$candidate\" ;; esac; done; true";
 pub const INSTALL_DESTINATION_PROBE_COMMAND: &str = "case \"$HOME\" in /*) destination=$HOME/.local/bin/boomux; lock=$HOME/.local/bin/.boomux.bootstrap.lock; state=clear; if [ -d \"$lock\" ] && [ ! -d \"$lock/committed\" ]; then state=stale; txn=$(/bin/cat \"$lock/id\" 2>/dev/null || true); case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) transaction=$HOME/.local/bin/$txn; watchdog=$(/bin/cat \"$transaction/watchdog_pid\" 2>/dev/null || true); expected_start=$(/bin/cat \"$transaction/watchdog_start\" 2>/dev/null || true); case \"$watchdog\" in ''|*[!0-9]*) ;; *) probe_os=$(/usr/bin/uname -s 2>/dev/null || true); case \"$probe_os\" in Linux) watchdog_stat=$(/bin/cat \"/proc/$watchdog/stat\" 2>/dev/null || true); watchdog_tail=${watchdog_stat##*) }; set -- $watchdog_tail; if [ \"$#\" -ge 20 ] && [ \"$1\" != Z ]; then shift 19; current_start=$1; else current_start=; fi ;; Darwin) watchdog_info=$(/bin/ps -p \"$watchdog\" -o state= -o lstart= 2>/dev/null || true); set -- $watchdog_info; if [ \"$#\" -ge 6 ]; then case \"$1\" in Z*) current_start= ;; *) shift; current_start=$* ;; esac; else current_start=; fi ;; *) current_start= ;; esac; if [ -n \"$expected_start\" ] && [ \"$current_start\" = \"$expected_start\" ]; then state=recovering; fi ;; esac ;; esac; fi; printf 'boomux-install-destination-v1\\0%s\\0%s\\0' \"$destination\" \"$state\" ;; *) exit 1 ;; esac";
 
 fn remote_daemon_command(executable: &RemoteExecutable, arguments: &str) -> String {
@@ -257,10 +257,15 @@ fn remote_integration_cleanup_plan(
             .get("name")
             .and_then(serde_json::Value::as_str)
             .filter(|name| {
-                crate::integrations::by_key(name)
-                    .is_some_and(|descriptor| descriptor.installation.is_some())
+                !name.is_empty() && name.len() <= 128 && !name.chars().any(char::is_control)
             })
-            .ok_or_else(|| invalid_probe("remote integration status returned an unknown name"))?;
+            .ok_or_else(|| invalid_probe("remote integration status returned an invalid name"))?;
+        if !crate::integrations::by_key(name)
+            .is_some_and(|descriptor| descriptor.installation.is_some())
+        {
+            preserved.push((name.to_owned(), None));
+            continue;
+        }
         let display_name = row
             .get("display_name")
             .and_then(serde_json::Value::as_str)
@@ -277,11 +282,7 @@ fn remote_integration_cleanup_plan(
             "current" => current.push(name.to_owned()),
             "modified" | "unavailable" => preserved.push((display_name.to_owned(), path)),
             "missing" => {}
-            _ => {
-                return Err(invalid_probe(
-                    "remote integration status returned an invalid state",
-                ));
-            }
+            _ => preserved.push((display_name.to_owned(), path)),
         }
     }
     Ok((current, preserved))
@@ -405,6 +406,12 @@ pub struct RemoteInstallPlan {
     intent: RemoteInstallIntent,
 }
 
+impl RemoteInstallPlan {
+    pub fn uses_recovery_helper(&self) -> bool {
+        matches!(self.intent, RemoteInstallIntent::RepairRegistered { .. })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteUninstallPlan {
     pub target: SshTarget,
@@ -416,12 +423,19 @@ pub struct RemoteUninstallPlan {
     current_integrations: Vec<String>,
     expected_node_id: String,
     expected_executable: String,
+    recovery: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RemoteInstallIntent {
     AutomaticCompatibility,
-    ExplicitRegisteredUpgrade { expected_node_id: String },
+    ExplicitRegisteredUpgrade {
+        expected_node_id: String,
+    },
+    RepairRegistered {
+        expected_node_id: String,
+        token: String,
+    },
 }
 
 impl RemoteInstallIntent {
@@ -443,7 +457,7 @@ impl RemoteInstallIntent {
     fn daemon_restart_required(&self, status: &RemoteDaemonStatus) -> bool {
         match self {
             Self::AutomaticCompatibility => status.restart_required(),
-            Self::ExplicitRegisteredUpgrade { .. } => {
+            Self::ExplicitRegisteredUpgrade { .. } | Self::RepairRegistered { .. } => {
                 matches!(status, RemoteDaemonStatus::Present { .. })
             }
         }
@@ -1338,6 +1352,8 @@ pub struct BootstrapSession {
     master: Child,
     master_pid: i32,
     stderr_reader: Option<MasterStderrReader>,
+    recovery_runner: Option<RemoteExecutable>,
+    recovery_suffix: Option<String>,
 }
 
 struct TerminalForegroundGuard {
@@ -1643,6 +1659,8 @@ impl BootstrapSession {
             master,
             master_pid,
             stderr_reader: Some(stderr_reader),
+            recovery_runner: None,
+            recovery_suffix: None,
         })
     }
 
@@ -1654,6 +1672,72 @@ impl BootstrapSession {
             &self.target,
             remote_command,
         )
+    }
+
+    fn prepare_recovery(
+        &mut self,
+        source: &RemoteInstallSource,
+        expected: &str,
+        timeout: Duration,
+    ) -> io::Result<(RemoteExecutable, serde_json::Value, String)> {
+        let suffix = Uuid::new_v4().simple().to_string();
+        self.recovery_suffix = Some(suffix.clone());
+        let command = recovery_upload_command(&suffix);
+        let output = run_streaming_command_capture(
+            self.command(&command),
+            source.bytes().to_vec(),
+            timeout,
+        )?;
+        let path = std::str::from_utf8(&output.stdout)
+            .map_err(|_| invalid_probe("recovery helper path invalid"))?;
+        let runner = RemoteExecutable::parse(path)?;
+        self.recovery_runner = Some(runner.clone());
+        let output = run_bounded_command(
+            self.command(&remote_daemon_command(
+                &runner,
+                &format!("__remote-maintenance probe {}", quote_posix_shell(expected)),
+            )),
+            timeout,
+        )?;
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|_| invalid_probe("recovery helper returned invalid metadata"))?;
+        let probe = value
+            .get("probe")
+            .filter(|p| {
+                p.get("version").and_then(|v| v.as_u64()) == Some(1)
+                    && p.get("node_id").and_then(|v| v.as_str()) == Some(expected)
+            })
+            .ok_or_else(|| invalid_probe("recovery helper identity mismatch"))?
+            .clone();
+        let token = value
+            .get("token")
+            .and_then(|v| v.as_str())
+            .filter(|v| v.len() == 64 && v.bytes().all(|b| b.is_ascii_hexdigit()))
+            .ok_or_else(|| invalid_probe("recovery authorization invalid"))?
+            .to_owned();
+        Ok((runner, probe, token))
+    }
+
+    fn run_recovery(
+        &self,
+        runner: &RemoteExecutable,
+        action: &str,
+        expected: &str,
+        token: &str,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        if self.recovery_runner.as_ref() != Some(runner) {
+            return Err(invalid_probe("recovery belongs to another session"));
+        }
+        let command = format!(
+            "{REMOTE_RUNTIME_PREFIX}if [ ! -x {} ]; then printf '%s\\n' 'boomux: recovery preparation expired; retry update or removal' >&2; exit 1; fi; exec {} __remote-maintenance {} {} {}",
+            quote_posix_shell(runner.as_str()),
+            quote_posix_shell(runner.as_str()),
+            quote_posix_shell(action),
+            quote_posix_shell(expected),
+            quote_posix_shell(token)
+        );
+        run_bounded_command(self.command(&command), timeout).map(|_| ())
     }
 
     pub fn plan(&mut self, timeout: Duration) -> io::Result<RemoteBootstrapPlan> {
@@ -1694,12 +1778,46 @@ impl BootstrapSession {
     ) -> io::Result<RemoteInstallPlan> {
         let discovery = discover_remote_in_session(self, timeout)?;
         let selection = inspect_remote_helpers_in_session(self, &discovery.executables, timeout)?;
+        if let Some(helper) = &selection.compatible {
+            RemoteInstallIntent::ExplicitRegisteredUpgrade {
+                expected_node_id: expected_node_id.into(),
+            }
+            .verify_helper_identity(helper)?;
+        }
+        if discovery.executables.is_empty()
+            || selection
+                .compatible
+                .as_ref()
+                .is_some_and(|helper| helper.executable != discovery.install_destination)
+        {
+            if let Some(error) = remote_recovery_error(discovery.recovery) {
+                return Err(error);
+            }
+            let source = select_install_source(discovery.platform)?;
+            let (runner, probe, token) =
+                self.prepare_recovery(&source, expected_node_id, timeout)?;
+            let destination = RemoteExecutable::parse(
+                probe
+                    .get("destination")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| invalid_probe("repair destination missing"))?,
+            )?;
+            return Ok(RemoteInstallPlan {
+                target: self.target.clone(),
+                destination,
+                source,
+                reason: RemoteInstallReason::Missing,
+                bootstrap_id: Some(self.id),
+                upgrade_helper: Some(runner),
+                intent: RemoteInstallIntent::RepairRegistered {
+                    expected_node_id: expected_node_id.into(),
+                    token,
+                },
+            });
+        }
         let helper = selection.compatible.ok_or_else(|| {
             if let Some(error) = remote_recovery_error(discovery.recovery) {
                 return error;
-            }
-            if discovery.executables.is_empty() {
-                return install_presence_required("No Boomux executable was found on this remote machine. Reinstall the standalone Boomux CLI on the owner, then retry Update remote. Existing Workspace state does not need to be reset merely because the executable is missing.");
             }
             incompatible_helper_cold_upgrade_required()
         })?;
@@ -1729,6 +1847,46 @@ impl BootstrapSession {
             return Err(error);
         }
         let selection = inspect_remote_helpers_in_session(self, &discovery.executables, timeout)?;
+        if let Some(helper) = &selection.compatible {
+            RemoteInstallIntent::ExplicitRegisteredUpgrade {
+                expected_node_id: expected_node_id.into(),
+            }
+            .verify_helper_identity(helper)?;
+        }
+        if discovery.executables.is_empty()
+            || selection
+                .compatible
+                .as_ref()
+                .is_some_and(|helper| helper.executable != discovery.install_destination)
+        {
+            let source = select_install_source(discovery.platform)?;
+            let (runner, probe, token) =
+                self.prepare_recovery(&source, expected_node_id, timeout)?;
+            let destination = RemoteExecutable::parse(
+                probe
+                    .get("destination")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| invalid_probe("removal destination missing"))?,
+            )?;
+            return Ok(RemoteUninstallPlan {
+                target: self.target.clone(),
+                destination,
+                helper_version: "temporary recovery helper".into(),
+                preserved_integrations: probe
+                    .get("preserved")
+                    .and_then(|v| v.as_array())
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|v| v.as_str().map(|name| (name.to_owned(), None)))
+                    .collect(),
+                helper: runner,
+                bootstrap_id: self.id,
+                current_integrations: vec![],
+                expected_node_id: expected_node_id.into(),
+                expected_executable: token,
+                recovery: true,
+            });
+        }
         let helper = selection.compatible.ok_or_else(|| {
             classified_error(
                 io::ErrorKind::Unsupported,
@@ -1784,6 +1942,7 @@ impl BootstrapSession {
             current_integrations,
             expected_node_id: expected_node_id.to_owned(),
             expected_executable,
+            recovery: false,
         })
     }
 
@@ -1795,7 +1954,7 @@ impl BootstrapSession {
     ) -> io::Result<()> {
         if plan.bootstrap_id != self.id
             || plan.target != self.target
-            || plan.helper != plan.destination
+            || (!plan.recovery && plan.helper != plan.destination)
         {
             return Err(classified_error(
                 io::ErrorKind::PermissionDenied,
@@ -1803,34 +1962,50 @@ impl BootstrapSession {
                 "remote uninstall authorization belongs to a different bootstrap endpoint",
             ));
         }
-        maintenance()?;
-        for integration in &plan.current_integrations {
-            let arguments = match integration.as_str() {
-                "opencode" => "integration uninstall opencode --json",
-                "pi" => "integration uninstall pi --json",
-                "claude" => "integration uninstall claude --json",
-                "codex" => "integration uninstall codex --json",
-                "kiro" => "integration uninstall kiro --json",
-                "kiro-v3" => "integration uninstall kiro-v3 --json",
-                _ => {
-                    return Err(invalid_probe(
-                        "remote uninstall plan contains an unknown integration",
-                    ));
-                }
-            };
-            let output = run_bounded_command(
-                self.command(&remote_daemon_command(&plan.helper, arguments)),
+        if plan.recovery {
+            maintenance()?;
+            self.run_recovery(
+                &plan.helper,
+                "remove",
+                &plan.expected_node_id,
+                &plan.expected_executable,
                 timeout,
             )?;
-            let value: serde_json::Value = serde_json::from_slice(&output.stdout)
-                .map_err(|_| invalid_probe("remote integration uninstall returned invalid JSON"))?;
-            if value.get("schema").and_then(serde_json::Value::as_str) != Some("boomux.cli/v1")
-                || value.get("command").and_then(serde_json::Value::as_str)
-                    != Some("integration.uninstall")
+            return Ok(());
+        }
+        maintenance()?;
+        for integration in &plan.current_integrations {
+            if !crate::integrations::by_key(integration)
+                .is_some_and(|descriptor| descriptor.installation.is_some())
             {
                 return Err(invalid_probe(
-                    "remote integration uninstall returned an invalid envelope",
+                    "remote uninstall plan contains an unknown integration",
                 ));
+            }
+            let arguments = format!("integration uninstall {} --json", integration);
+            let cleanup = (|| -> io::Result<()> {
+                let output = run_bounded_command(
+                    self.command(&remote_daemon_command(&plan.helper, &arguments)),
+                    timeout,
+                )?;
+                let value: serde_json::Value =
+                    serde_json::from_slice(&output.stdout).map_err(|_| {
+                        invalid_probe("remote integration uninstall returned invalid JSON")
+                    })?;
+                if value.get("schema").and_then(serde_json::Value::as_str) != Some("boomux.cli/v1")
+                    || value.get("command").and_then(serde_json::Value::as_str)
+                        != Some("integration.uninstall")
+                {
+                    return Err(invalid_probe(
+                        "remote integration uninstall returned an invalid envelope",
+                    ));
+                }
+                Ok(())
+            })();
+            if cleanup.is_err() {
+                eprintln!(
+                    "boomux: could not clean up the {integration} integration; its remaining assets are preserved"
+                );
             }
             maintenance()?;
         }
@@ -1917,6 +2092,42 @@ impl BootstrapSession {
                 "bootstrap_authentication_failed",
                 "remote install authorization belongs to a different bootstrap endpoint",
             ));
+        }
+        if let RemoteInstallIntent::RepairRegistered {
+            expected_node_id,
+            token,
+        } = &plan.intent
+        {
+            let runner = plan
+                .upgrade_helper
+                .as_ref()
+                .ok_or_else(|| invalid_probe("repair helper missing"))?;
+            self.run_recovery(runner, "repair", expected_node_id, token, timeout)
+                .map_err(|error| {
+                    if recovery_disposition(&error)
+                        == BootstrapRecoveryDisposition::NoRemoteMutation
+                    {
+                        error
+                    } else {
+                        with_recovery(error, BootstrapRecoveryDisposition::OutcomeUnknown)
+                    }
+                })?;
+            maintenance()?;
+            let selection = inspect_remote_helpers_in_session(
+                &self,
+                std::slice::from_ref(&plan.destination),
+                timeout,
+            )?;
+            let helper = selection
+                .compatible
+                .ok_or_else(|| invalid_probe("repaired helper did not answer"))?;
+            RemoteInstallIntent::ExplicitRegisteredUpgrade {
+                expected_node_id: expected_node_id.clone(),
+            }
+            .verify_helper_identity(&helper)?;
+            let mut connection = self.connect(helper, timeout)?;
+            connection.ping_with_timeout(timeout)?;
+            return Ok(connection);
         }
         let upgrade_helper = if plan.reason == RemoteInstallReason::Upgrade {
             Some(plan.upgrade_helper.as_ref().ok_or_else(|| {
@@ -2264,8 +2475,19 @@ fn slave_command(
     command
 }
 
+fn recovery_upload_command(suffix: &str) -> String {
+    format!(
+        "{REMOTE_RUNTIME_PREFIX}umask 077; /usr/bin/find \"$XDG_RUNTIME_DIR\" -maxdepth 1 -type f -name 'boomux-recovery-*' -mmin +9 -delete; count=0; for staged in \"$XDG_RUNTIME_DIR\"/boomux-recovery-*; do [ ! -e \"$staged\" ] || count=$((count + 1)); done; [ \"$count\" -lt 2 ] || {{ printf '%s\\n' 'boomux: temporary recovery helpers are still active; retry in ten minutes' >&2; exit 1; }}; runner=$XDG_RUNTIME_DIR/boomux-recovery-{suffix}; (set -C; /bin/cat > \"$runner\") || {{ /bin/rm -f -- \"$runner\"; exit 1; }}; /bin/chmod 700 \"$runner\" || exit 1; printf '%s' \"$runner\""
+    )
+}
+
 impl Drop for BootstrapSession {
     fn drop(&mut self) {
+        if let Some(suffix) = &self.recovery_suffix {
+            let _ = run_bounded_command(self.command(&format!(
+                "{REMOTE_RUNTIME_PREFIX}/bin/rm -f -- \"$XDG_RUNTIME_DIR/boomux-recovery-{suffix}\""
+            )), Duration::from_secs(2));
+        }
         let _ = kill_process_group(self.master_pid, &mut self.master);
         if let Some(reader) = self.stderr_reader.take() {
             let _ = reader.finish();
@@ -3816,9 +4038,54 @@ fn run_bounded_command(mut command: Command, timeout: Duration) -> io::Result<Ss
 }
 
 fn classify_ssh_command_failure(status: Option<i32>, stderr: &[u8]) -> io::Error {
+    if status == Some(2)
+        && stderr
+            .windows(b"__remote-maintenance".len())
+            .any(|w| w == b"__remote-maintenance")
+    {
+        return with_recovery(
+            classified_error(
+                io::ErrorKind::Unsupported,
+                "remote_recovery_unsupported",
+                "the selected binary does not support remote recovery; use a release that includes this workflow",
+            ),
+            BootstrapRecoveryDisposition::NoRemoteMutation,
+        );
+    }
     // Surface known ownership refusals without relaying arbitrary remote stderr
     // (which can contain secrets or terminal control sequences).
     if status == Some(1) {
+        for message in [
+            "recovery preparation expired; retry update or removal",
+            "remote configuration could not be read; repair it on the owner before updating",
+            "saved remote state cannot be read by this Boomux version; use a compatible release",
+            "temporary recovery helpers are still active; retry in ten minutes",
+            "package-managed executable; use its package manager",
+            "this executable belongs to a Desktop bundle; use its Desktop installer",
+            "remote Node identity changed; refusing maintenance",
+            "running daemon belongs to another Node",
+            "running daemon executable cannot be verified",
+            "installation changed after maintenance preparation; retry",
+            "another recovery operation is active; retry shortly",
+            "another update is finishing recovery; retry shortly",
+            "running daemon predates safe executable handoff; repair requires protocol 52 or newer",
+            "maintenance directory is not privately owned",
+            "installation record belongs to another Node or version",
+        ] {
+            if stderr
+                .split(|b| *b == b'\n')
+                .any(|line| line.strip_prefix(b"boomux: ") == Some(message.as_bytes()))
+            {
+                return with_recovery(
+                    classified_error(
+                        io::ErrorKind::PermissionDenied,
+                        "remote_maintenance_refused",
+                        message,
+                    ),
+                    BootstrapRecoveryDisposition::NoRemoteMutation,
+                );
+            }
+        }
         for (reason, message) in [
             (
                 "this Boomux executable is a source or development build; remove it through its build or installation workflow",
@@ -6772,25 +7039,69 @@ mod tests {
     }
 
     #[test]
-    fn explicit_upgrade_missing_helper_requests_install_without_cold_reset() {
+    fn recovery_upload_bounds_staging_and_reclaims_expired_helpers() {
         let runtime = runtime_directory();
-        let ssh = write_session_bootstrap_ssh(&runtime, "", "");
+        fs::create_dir_all(&runtime).unwrap();
+        fs::set_permissions(&runtime, fs::Permissions::from_mode(0o700)).unwrap();
+        let upload = |suffix: &str| {
+            let mut command = Command::new("/bin/sh");
+            command
+                .args(["-c", &recovery_upload_command(suffix)])
+                .env("HOME", &runtime)
+                .env("XDG_RUNTIME_DIR", &runtime);
+            run_streaming_command_capture(
+                command,
+                b"recovery candidate".to_vec(),
+                Duration::from_secs(2),
+            )
+        };
+        let first = upload("first").unwrap();
+        let first = PathBuf::from(String::from_utf8(first.stdout).unwrap());
+        let second = upload("second").unwrap();
+        let second = PathBuf::from(String::from_utf8(second.stdout).unwrap());
+        assert_eq!(fs::read(&first).unwrap(), b"recovery candidate");
+        assert_eq!(fs::metadata(&first).unwrap().mode() & 0o777, 0o700);
+        assert!(upload("third").is_err());
+        let old = std::time::SystemTime::now() - Duration::from_secs(12 * 60);
+        for file in [&first, &second] {
+            fs::File::open(file)
+                .unwrap()
+                .set_times(fs::FileTimes::new().set_modified(old))
+                .unwrap();
+        }
+        upload("third").unwrap();
+        assert!(!first.exists());
+        assert!(!second.exists());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn explicit_upgrade_missing_helper_prepares_identity_pinned_recovery() {
+        let runtime = runtime_directory();
+        let node = Uuid::new_v4().to_string();
+        let response = serde_json::json!({"probe":{"version":1,"node_id":node,
+            "destination":"/home/person/.local/bin/boomux","preserved":[]},"token":"a".repeat(64)});
+        let cases = format!(
+            "  *'__remote-maintenance probe '*) printf '%s' '{}' ;;\n  *'runner=$XDG_RUNTIME_DIR/boomux-recovery-'*) cat >/dev/null; printf /tmp/boomux-recovery-fixture ;;",
+            response
+        );
+        let ssh = write_session_bootstrap_ssh(&runtime, &cases, "");
         let mut session = BootstrapSession::open_at(
             &runtime,
             None,
             SshTarget::parse("workbox").unwrap(),
             SshAuthenticationMode::Batch,
-            Duration::from_secs(1),
+            Duration::from_secs(5),
             ssh.as_os_str(),
         )
         .unwrap();
-        let error = session
-            .plan_explicit_upgrade(&Uuid::new_v4().to_string(), Duration::from_secs(1))
-            .unwrap_err();
-        assert_eq!(error_code(&error), "install_required");
-        assert!(error.to_string().contains("Reinstall the standalone"));
-        assert!(!error.to_string().contains("pre-protocol-47"));
-        assert!(!error.to_string().contains("daemon stop"));
+        let plan = session
+            .plan_explicit_upgrade(&node, Duration::from_secs(5))
+            .unwrap();
+        assert!(plan.uses_recovery_helper());
+        assert!(
+            matches!(plan.intent, RemoteInstallIntent::RepairRegistered { expected_node_id, .. } if expected_node_id == node)
+        );
         drop(session);
         fs::remove_dir_all(runtime).unwrap();
     }
@@ -6802,8 +7113,8 @@ mod tests {
         let helper = compatible_helper_script(&node_id);
         let ssh = write_session_bootstrap_ssh(
             &runtime,
-            &format!("  \"'/good/boomux' __federation-stdio\") {helper} ;;"),
-            "/good/boomux\\0",
+            &format!("  \"'/home/person/.local/bin/boomux' __federation-stdio\") {helper} ;;"),
+            "/home/person/.local/bin/boomux\\0",
         );
         let mut session = BootstrapSession::open_at(
             &runtime,
@@ -6821,7 +7132,7 @@ mod tests {
         assert_eq!(plan.reason, RemoteInstallReason::Upgrade);
         assert_eq!(
             plan.upgrade_helper.as_ref().unwrap().as_str(),
-            "/good/boomux"
+            "/home/person/.local/bin/boomux"
         );
         assert!(matches!(
             plan.source,
@@ -6880,12 +7191,21 @@ mod tests {
             status["data"]["integrations"].as_array_mut().unwrap().push(serde_json::json!({
             "name":kiro, "display_name":"Kiro CLI v3", "asset":{"state":"current","path":"/kiro"}
         }));
+            status["data"]["integrations"]
+                .as_array_mut()
+                .unwrap()
+                .push(serde_json::json!({"name":"future-host"}));
             let status = serde_json::to_string(&status).unwrap();
             let removed = r#"{"schema":"boomux.cli/v1","command":"integration.uninstall","data":{"integrations":[]}}"#;
+            let cleanup = if kiro == "kiro" {
+                "exit 1".to_owned()
+            } else {
+                format!("printf '%s' '{removed}'")
+            };
             let ssh = write_session_bootstrap_ssh(
                 &runtime,
                 &format!(
-                    "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall {kiro} --json'*) printf '%s' '{removed}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
+                    "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall {kiro} --json'*) {cleanup} ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
                     quote_posix_shell(marker.to_str().unwrap())
                 ),
                 "/home/person/.local/bin/boomux\\0",
@@ -6905,7 +7225,10 @@ mod tests {
             assert!(plan.current_integrations.iter().any(|name| name == kiro));
             assert_eq!(
                 plan.preserved_integrations,
-                vec![("Pi".into(), Some("/modified".into()))]
+                vec![
+                    ("Pi".into(), Some("/modified".into())),
+                    ("future-host".into(), None)
+                ]
             );
             let mut renewals = 0;
             session

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1495,7 +1495,12 @@ impl BootstrapSession {
             prepare_ssh_directory(runtime_directory, user_config)?;
         let mut command = Command::new(program);
         append_ssh_security_options(&mut command, &config_path, &control_path, authentication);
+        // Bound connection/key exchange separately from the time allowed for a
+        // person to complete password, browser, or host-key prompts.
+        let connection_seconds = timeout.as_secs().clamp(1, 15);
         command
+            .args(["-o", &format!("ConnectTimeout={connection_seconds}")])
+            .args(["-o", "ConnectionAttempts=1"])
             .args(["-o", "ControlMaster=yes"])
             .args(["-o", "ControlPersist=no"])
             .arg("-N")
@@ -1621,7 +1626,7 @@ impl BootstrapSession {
                 let _ = fs::remove_dir_all(&directory);
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
-                    "SSH bootstrap authentication timed out",
+                    "SSH connection or sign-in did not complete before the deadline; check that the remote machine is online and reachable, then retry",
                 ));
             }
             thread::sleep(CHILD_POLL_INTERVAL);
@@ -1690,6 +1695,9 @@ impl BootstrapSession {
         let helper = selection.compatible.ok_or_else(|| {
             if let Some(error) = remote_recovery_error(discovery.recovery) {
                 return error;
+            }
+            if discovery.executables.is_empty() {
+                return install_presence_required("No Boomux executable was found on this remote machine. Reinstall the standalone Boomux CLI on the owner, then retry Update remote. Existing Workspace state does not need to be reset merely because the executable is missing.");
             }
             incompatible_helper_cold_upgrade_required()
         })?;
@@ -2489,6 +2497,27 @@ fn classify_ssh_start_failure(status: Option<i32>, stderr: &[u8]) -> io::Error {
             io::ErrorKind::PermissionDenied,
             "bootstrap_authentication_failed",
             "SSH authentication or host-key verification failed",
+        )
+    } else if stderr.contains("timed out") || stderr.contains("timeout") {
+        classified_error(
+            io::ErrorKind::TimedOut,
+            "bootstrap_transport_failed",
+            "SSH connection timed out; check that the remote machine is online, its network or VPN is connected, and SSH is reachable, then retry",
+        )
+    } else if stderr.contains("could not resolve hostname") {
+        classified_error(
+            io::ErrorKind::NotFound,
+            "bootstrap_transport_failed",
+            "SSH could not resolve the remote hostname; check the stored SSH route and network or VPN connection",
+        )
+    } else if stderr.contains("connection refused")
+        || stderr.contains("no route to host")
+        || stderr.contains("network is unreachable")
+    {
+        classified_error(
+            io::ErrorKind::ConnectionRefused,
+            "bootstrap_transport_failed",
+            "SSH could not reach the remote service; check that the machine is online and accepting SSH connections",
         )
     } else {
         classified_error(
@@ -5830,6 +5859,59 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_connection_has_short_deadline_without_shortening_signin() {
+        for (timeout, expected) in [(120, 15), (2, 2)] {
+            let runtime = runtime_directory();
+            fs::create_dir_all(&runtime).unwrap();
+            let ssh = write_master_stderr_ssh(
+                &runtime,
+                &format!(
+                    "found=false; attempts=false; for arg do [ \"$arg\" = ConnectTimeout={expected} ] && found=true; [ \"$arg\" = ConnectionAttempts=1 ] && attempts=true; done; $found && $attempts || exit 64; : > \"$control.ready\"; while :; do /bin/sleep 60; done"
+                ),
+            );
+            let session = BootstrapSession::open_at(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                SshAuthenticationMode::Interactive,
+                Duration::from_secs(timeout),
+                ssh.as_os_str(),
+            )
+            .unwrap();
+            drop(session);
+            assert!(
+                fs::read_dir(&runtime)
+                    .unwrap()
+                    .filter_map(Result::ok)
+                    .all(|entry| !entry.file_type().unwrap().is_dir())
+            );
+            fs::remove_dir_all(runtime).unwrap();
+        }
+    }
+
+    #[test]
+    fn bootstrap_network_failures_are_actionable_and_do_not_echo_private_stderr() {
+        for stderr in [
+            "connect to host private-host port 22: Connection timed out SECRET",
+            "Connection refused SECRET",
+            "No route to host SECRET",
+            "Network is unreachable SECRET",
+            "Could not resolve hostname private-host SECRET",
+        ] {
+            let error = classify_ssh_start_failure(Some(255), stderr.as_bytes());
+            assert_eq!(error_code(&error), "bootstrap_transport_failed");
+            assert!(error.to_string().contains("check"));
+            assert!(!error.to_string().contains("SECRET"));
+            assert!(!error.to_string().contains("private-host"));
+            assert_ne!(error.kind(), io::ErrorKind::PermissionDenied);
+        }
+        assert_eq!(
+            error_code(&classify_ssh_start_failure(Some(255), b"Permission denied")),
+            "bootstrap_authentication_failed"
+        );
+    }
+
+    #[test]
     fn master_stderr_is_mirrored_live_only_for_interactive_authentication() {
         let challenge = b"To authenticate, visit:\nhttps://login.tailscale.test/a?c=123\n\xff";
         for authentication in [
@@ -6678,6 +6760,30 @@ mod tests {
         };
         assert_eq!(error_code(&error), "node_identity_changed");
         assert!(!mutated.exists());
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn explicit_upgrade_missing_helper_requests_install_without_cold_reset() {
+        let runtime = runtime_directory();
+        let ssh = write_session_bootstrap_ssh(&runtime, "", "");
+        let mut session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let error = session
+            .plan_explicit_upgrade(&Uuid::new_v4().to_string(), Duration::from_secs(1))
+            .unwrap_err();
+        assert_eq!(error_code(&error), "install_required");
+        assert!(error.to_string().contains("Reinstall the standalone"));
+        assert!(!error.to_string().contains("pre-protocol-47"));
+        assert!(!error.to_string().contains("daemon stop"));
+        drop(session);
         fs::remove_dir_all(runtime).unwrap();
     }
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -1947,6 +1947,11 @@ impl BootstrapSession {
                 ));
             }
             Err(first_error) => {
+                // Exit 73 is an explicit refusal before this transaction owns
+                // the lock. Do not retry or claim an unknown mutation outcome.
+                if error_code(&first_error) == "busy" {
+                    return Err(first_error);
+                }
                 if let Err(error) = maintenance() {
                     let failure = post_install_failure("stream", error);
                     return Err(
@@ -3852,7 +3857,7 @@ fn classify_ssh_command_failure(status: Option<i32>, stderr: &[u8]) -> io::Error
         return classified_error(
             io::ErrorKind::ResourceBusy,
             "busy",
-            "another remote Boomux bootstrap transaction is active",
+            "another remote Boomux update is active or finishing cleanup; wait up to three minutes and retry",
         );
     }
     if status == Some(92) {
@@ -7454,6 +7459,77 @@ mod tests {
         assert!(backup.exists());
         assert_eq!(fs::read_to_string(&count).unwrap(), "2");
         drop(connection);
+        fs::remove_dir_all(runtime).unwrap();
+    }
+
+    #[test]
+    fn explicit_upgrade_busy_upload_does_not_retry_or_claim_unknown_outcome() {
+        let runtime = runtime_directory();
+        fs::create_dir_all(&runtime).unwrap();
+        let destination = runtime.join("destination");
+        let backup = runtime.join("backup");
+        let count = runtime.join("count");
+        let committed = runtime.join("committed");
+        let restarted = runtime.join("restarted");
+        fs::write(&destination, b"previous-helper").unwrap();
+        let node_id = Uuid::new_v4().to_string();
+        let helper = compatible_helper_script(&node_id);
+        let ssh = runtime.join("ssh");
+        fs::write(
+            &ssh,
+            format!(
+                "#!/bin/sh\n{control}\nlast=\nfor arg do last=$arg; done\ncase \"$last\" in\n  *'boomux-install-transaction-v1'*) printf x >> {committed}; exit 73 ;;\n  *'committed=$lock/committed'*) cat >/dev/null; [ \"$(cat {count})\" -eq 3 ]; : > {committed}; printf 'boomux-install-commit-v1\\0committed\\0' ;;\n  *': > \"$transaction/restarted\"'*) cat >/dev/null; : > {restarted} ;;\n  *'transaction/watchdog_pid'*'restore_install'*) cat >/dev/null; rm -f {destination}; mv {backup} {destination} ;;\n  *'daemon status --json'*) printf '%s' '{{\"schema\":\"boomux.cli/v1\",\"command\":\"daemon.status\",\"data\":{{\"protocol_version\":38}}}}' ;;\n  *'daemon restart'*) : > {restarted} ;;\n  *\"'/home/person/.local/bin/boomux' __federation-stdio\") n=0; [ ! -f {count} ] || n=$(cat {count}); n=$((n + 1)); printf '%s' \"$n\" > {count}; {helper} ;;\n  *) exit 64 ;;\nesac\n",
+                control = CONTROL_MASTER_SCRIPT,
+                destination = quote_posix_shell(destination.to_str().unwrap()),
+                backup = quote_posix_shell(backup.to_str().unwrap()),
+                count = quote_posix_shell(count.to_str().unwrap()),
+                committed = quote_posix_shell(committed.to_str().unwrap()),
+                restarted = quote_posix_shell(restarted.to_str().unwrap()),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&ssh, fs::Permissions::from_mode(0o700)).unwrap();
+        add_fake_daemon_identity(&ssh, "/home/person/.local/bin/boomux");
+        let session = BootstrapSession::open_at(
+            &runtime,
+            None,
+            SshTarget::parse("workbox").unwrap(),
+            SshAuthenticationMode::Batch,
+            Duration::from_secs(1),
+            ssh.as_os_str(),
+        )
+        .unwrap();
+        let plan = RemoteInstallPlan {
+            target: SshTarget::parse("workbox").unwrap(),
+            destination: RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            source: RemoteInstallSource::CurrentBinary {
+                path: runtime.join("pinned"),
+                sha256: format!("{:x}", Sha256::digest(b"replacement")),
+                bytes: b"replacement".to_vec(),
+            },
+            reason: RemoteInstallReason::Upgrade,
+            bootstrap_id: Some(session.id),
+            upgrade_helper: Some(
+                RemoteExecutable::parse("/home/person/.local/bin/boomux").unwrap(),
+            ),
+            intent: RemoteInstallIntent::ExplicitRegisteredUpgrade {
+                expected_node_id: node_id,
+            },
+        };
+
+        let error = session
+            .install_and_connect(&plan, Duration::from_secs(1))
+            .err()
+            .expect("busy upload must fail");
+        assert_eq!(error_code(&error), "busy");
+        assert_eq!(
+            recovery_disposition(&error),
+            BootstrapRecoveryDisposition::NoRemoteMutation
+        );
+        assert!(error.to_string().contains("three minutes"));
+        assert_eq!(fs::read(&committed).unwrap(), b"x");
+        assert!(!restarted.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"previous-helper");
         fs::remove_dir_all(runtime).unwrap();
     }
 

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -250,14 +250,16 @@ fn remote_integration_cleanup_plan(
         .pointer("/data/integrations")
         .and_then(serde_json::Value::as_array)
         .ok_or_else(|| invalid_probe("remote integration status omitted integrations"))?;
-    let allowed = ["opencode", "pi", "claude", "codex", "kiro"];
     let mut current = Vec::new();
     let mut preserved = Vec::new();
     for row in rows {
         let name = row
             .get("name")
             .and_then(serde_json::Value::as_str)
-            .filter(|name| allowed.contains(name))
+            .filter(|name| {
+                crate::integrations::by_key(name)
+                    .is_some_and(|descriptor| descriptor.installation.is_some())
+            })
             .ok_or_else(|| invalid_probe("remote integration status returned an unknown name"))?;
         let display_name = row
             .get("display_name")
@@ -1809,6 +1811,7 @@ impl BootstrapSession {
                 "claude" => "integration uninstall claude --json",
                 "codex" => "integration uninstall codex --json",
                 "kiro" => "integration uninstall kiro --json",
+                "kiro-v3" => "integration uninstall kiro-v3 --json",
                 _ => {
                     return Err(invalid_probe(
                         "remote uninstall plan contains an unknown integration",
@@ -6866,47 +6869,55 @@ mod tests {
 
     #[test]
     fn explicit_uninstall_uses_one_session_and_preserves_modified_integrations() {
-        let runtime = runtime_directory();
-        let marker = runtime.join("uninstalled");
-        let node_id = Uuid::new_v4().to_string();
-        let helper = compatible_helper_script(&node_id);
-        let executable = "/home/person/.local/bin/boomux";
-        let status = r#"{"schema":"boomux.cli/v1","command":"integration.status","data":{"integrations":[{"name":"opencode","display_name":"OpenCode","asset":{"state":"current","path":"/current"}},{"name":"pi","display_name":"Pi","asset":{"state":"modified","path":"/modified"}}]}}"#;
-        let removed = r#"{"schema":"boomux.cli/v1","command":"integration.uninstall","data":{"integrations":[]}}"#;
-        let ssh = write_session_bootstrap_ssh(
-            &runtime,
-            &format!(
-                "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
-                quote_posix_shell(marker.to_str().unwrap())
-            ),
-            "/home/person/.local/bin/boomux\\0",
-        );
-        let mut session = BootstrapSession::open_at(
-            &runtime,
-            None,
-            SshTarget::parse("workbox").unwrap(),
-            SshAuthenticationMode::Batch,
-            Duration::from_secs(1),
-            ssh.as_os_str(),
-        )
-        .unwrap();
-        let plan = session
-            .plan_explicit_uninstall(&node_id, Duration::from_secs(1))
+        for kiro in ["kiro-v3", "kiro"] {
+            let runtime = runtime_directory();
+            let marker = runtime.join("uninstalled");
+            let node_id = Uuid::new_v4().to_string();
+            let helper = compatible_helper_script(&node_id);
+            let executable = "/home/person/.local/bin/boomux";
+            let status = r#"{"schema":"boomux.cli/v1","command":"integration.status","data":{"integrations":[{"name":"opencode","display_name":"OpenCode","asset":{"state":"current","path":"/current"}},{"name":"pi","display_name":"Pi","asset":{"state":"modified","path":"/modified"}}]}}"#;
+            let mut status: serde_json::Value = serde_json::from_str(status).unwrap();
+            status["data"]["integrations"].as_array_mut().unwrap().push(serde_json::json!({
+            "name":kiro, "display_name":"Kiro CLI v3", "asset":{"state":"current","path":"/kiro"}
+        }));
+            let status = serde_json::to_string(&status).unwrap();
+            let removed = r#"{"schema":"boomux.cli/v1","command":"integration.uninstall","data":{"integrations":[]}}"#;
+            let ssh = write_session_bootstrap_ssh(
+                &runtime,
+                &format!(
+                    "  \"'{executable}' __federation-stdio\") {helper} ;;\n  \"'{executable}' --version\") printf 'boomux 1.0.1\\n' ;;\n  *'__uninstall-fingerprint'*) printf 'boomux-uninstall-fingerprint-v1 token\\n' ;;\n  *'integration status --json'*) printf '%s' '{status}' ;;\n  *'integration uninstall {kiro} --json'*) printf '%s' '{removed}' ;;\n  *'integration uninstall opencode --json'*) printf '%s' '{removed}' ;;\n  *'__uninstall-remote'*) : > {} ;;",
+                    quote_posix_shell(marker.to_str().unwrap())
+                ),
+                "/home/person/.local/bin/boomux\\0",
+            );
+            let mut session = BootstrapSession::open_at(
+                &runtime,
+                None,
+                SshTarget::parse("workbox").unwrap(),
+                SshAuthenticationMode::Batch,
+                Duration::from_secs(1),
+                ssh.as_os_str(),
+            )
             .unwrap();
-        assert_eq!(
-            plan.preserved_integrations,
-            vec![("Pi".into(), Some("/modified".into()))]
-        );
-        let mut renewals = 0;
-        session
-            .uninstall_registered(&plan, Duration::from_secs(1), || {
-                renewals += 1;
-                Ok(())
-            })
-            .unwrap();
-        assert!(renewals >= 3);
-        assert!(marker.exists());
-        fs::remove_dir_all(runtime).unwrap();
+            let plan = session
+                .plan_explicit_uninstall(&node_id, Duration::from_secs(1))
+                .unwrap();
+            assert!(plan.current_integrations.iter().any(|name| name == kiro));
+            assert_eq!(
+                plan.preserved_integrations,
+                vec![("Pi".into(), Some("/modified".into()))]
+            );
+            let mut renewals = 0;
+            session
+                .uninstall_registered(&plan, Duration::from_secs(1), || {
+                    renewals += 1;
+                    Ok(())
+                })
+                .unwrap();
+            assert!(renewals >= 3);
+            assert!(marker.exists());
+            fs::remove_dir_all(runtime).unwrap();
+        }
     }
 
     #[test]

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -226,7 +226,7 @@ pub(crate) fn remote_uninstall(
     Ok(())
 }
 
-fn stop_web_gateways() -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn stop_web_gateways() -> Result<(), Box<dyn std::error::Error>> {
     let runtime = client::socket_path()?
         .parent()
         .ok_or_else(|| io::Error::other("Boomux runtime socket has no parent"))?

--- a/src/update.rs
+++ b/src/update.rs
@@ -444,7 +444,7 @@ pub(crate) fn remove_uninstall_target(target: &UninstallTarget) -> io::Result<()
     sync_directory(parent)
 }
 
-fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
+pub(crate) fn rename_noreplace(from: &Path, to: &Path) -> io::Result<()> {
     let from = std::ffi::CString::new(from.as_os_str().as_bytes()).map_err(io::Error::other)?;
     let to = std::ffi::CString::new(to.as_os_str().as_bytes()).map_err(io::Error::other)?;
     boomux::platform::rename_noreplace(libc::AT_FDCWD, &from, libc::AT_FDCWD, &to)
@@ -598,7 +598,7 @@ fn classify_installation(
     }
 }
 
-fn is_package_path(path: &Path) -> bool {
+pub(crate) fn is_package_path(path: &Path) -> bool {
     [
         "/usr/bin/boomux",
         "/usr/local/bin/boomux",
@@ -845,6 +845,12 @@ fn replace_with_rollback(
 }
 
 trait TransactionFs {
+    fn backup_path(&self, parent: &Path) -> PathBuf {
+        parent.join(format!(".boomux-backup-{}", Uuid::new_v4()))
+    }
+    fn backup_is_hard_link(&self) -> bool {
+        true
+    }
     fn hard_link(&self, source: &Path, destination: &Path) -> io::Result<()>;
     fn rename(&self, source: &Path, destination: &Path) -> io::Result<()>;
     fn remove_file(&self, path: &Path) -> io::Result<()>;
@@ -913,13 +919,19 @@ fn replace_with_rollback_using(
             "downloaded Boomux candidate changed before activation",
         ));
     }
-    let backup = parent.join(format!(".boomux-backup-{}", Uuid::new_v4()));
+    let backup = operations.backup_path(parent);
     operations.hard_link(target, &backup)?;
     if let Err(error) = operations.sync_directory(parent) {
         let _ = operations.remove_file(&backup);
         return Err(error);
     }
-    if !same_file_after_backup(&fingerprint(target)?, baseline) {
+    let after_backup = fingerprint(target)?;
+    let unchanged = if operations.backup_is_hard_link() {
+        same_file_after_backup(&after_backup, baseline)
+    } else {
+        &after_backup == baseline
+    };
+    if !unchanged {
         let _ = operations.remove_file(&backup);
         return Err(io::Error::new(
             io::ErrorKind::AlreadyExists,
@@ -1103,7 +1115,7 @@ fn daemon_disposition(target: &Path) -> io::Result<DaemonDisposition> {
     })
 }
 
-fn reserve_daemon_absence(socket: &Path) -> io::Result<client::DaemonLockReservation> {
+pub(crate) fn reserve_daemon_absence(socket: &Path) -> io::Result<client::DaemonLockReservation> {
     client::reserve_daemon_lock(socket)?.ok_or_else(|| {
         io::Error::new(
             io::ErrorKind::ResourceBusy,
@@ -1113,14 +1125,14 @@ fn reserve_daemon_absence(socket: &Path) -> io::Result<client::DaemonLockReserva
 }
 
 #[cfg(target_os = "linux")]
-struct DaemonExecutable {
-    pid: u32,
-    path: PathBuf,
+pub(crate) struct DaemonExecutable {
+    pub(crate) pid: u32,
+    pub(crate) path: PathBuf,
     fingerprint: FileFingerprint,
 }
 
 #[cfg(target_os = "linux")]
-fn daemon_executable(daemon: &client::Client) -> Option<DaemonExecutable> {
+pub(crate) fn daemon_executable(daemon: &client::Client) -> Option<DaemonExecutable> {
     let credentials = daemon.daemon_process_credentials().ok()?;
     if credentials.uid != unsafe { libc::geteuid() } {
         return None;
@@ -1148,14 +1160,14 @@ fn daemon_executable(daemon: &client::Client) -> Option<DaemonExecutable> {
 }
 
 #[cfg(not(target_os = "linux"))]
-struct DaemonExecutable {
-    pid: u32,
-    path: PathBuf,
+pub(crate) struct DaemonExecutable {
+    pub(crate) pid: u32,
+    pub(crate) path: PathBuf,
     fingerprint: FileFingerprint,
 }
 
 #[cfg(not(target_os = "linux"))]
-fn daemon_executable(_daemon: &client::Client) -> Option<DaemonExecutable> {
+pub(crate) fn daemon_executable(_daemon: &client::Client) -> Option<DaemonExecutable> {
     None
 }
 
@@ -1322,6 +1334,122 @@ fn refusal_message(status: &UpdateStatus) -> &'static str {
         },
         UpdateState::UpdateAvailable => "this Boomux installation is not eligible for self-update",
     }
+}
+
+/// Confirm a recovery handoff against both the kernel's executable and the installed inode.
+pub(crate) fn verify_recovery_executable(daemon: &client::Client, target: &Path) -> io::Result<()> {
+    let installed = fingerprint(target)?;
+    let executable = daemon_executable(daemon)
+        .ok_or_else(|| io::Error::other("replacement daemon executable could not be verified"))?;
+    if executable.path != target || !same_candidate(&executable.fingerprint, &installed) {
+        return Err(io::Error::other(
+            "replacement daemon did not use the installed executable",
+        ));
+    }
+    Ok(())
+}
+
+/// Use the normal rollback transaction for an owner-verified recovery target.
+pub(crate) fn replace_for_recovery(
+    target: &Path,
+    candidate: &Path,
+    expected_node: &str,
+    notifications: crate::protocol::NotificationDeliveryConfig,
+    running: bool,
+) -> io::Result<()> {
+    let baseline = fingerprint(target)?;
+    let pinned = fingerprint(candidate)?;
+    let handoff = || -> io::Result<()> {
+        if running {
+            let daemon = client::connect().map_err(|e| io::Error::other(e.to_string()))?;
+            if daemon
+                .node_identity()
+                .map_err(|e| io::Error::other(e.to_string()))?
+                != expected_node
+            {
+                return Err(io::Error::other("Node identity changed before handoff"));
+            }
+            daemon
+                .restart_with_executable(target.to_path_buf(), notifications.clone())
+                .map_err(|e| io::Error::other(e.to_string()))?;
+            verify_recovery_executable(&daemon, target)?;
+        }
+        Ok(())
+    };
+    replace_with_rollback_using(
+        &RecoveryTransactionFs,
+        ReplacementTransaction {
+            target,
+            candidate,
+            baseline: &baseline,
+            candidate_fingerprint: &pinned,
+        },
+        handoff,
+        handoff,
+        |warning| eprintln!("boomux: {warning}"),
+    )
+}
+
+// Recovery uses one reserved copy, so interruption cannot leave the installed
+// executable with an extra hard link or accumulate unbounded rollback files.
+struct RecoveryTransactionFs;
+impl TransactionFs for RecoveryTransactionFs {
+    fn backup_path(&self, parent: &Path) -> PathBuf {
+        parent.join(".boomux-recovery-backup")
+    }
+    fn backup_is_hard_link(&self) -> bool {
+        false
+    }
+    fn hard_link(&self, source: &Path, backup: &Path) -> io::Result<()> {
+        remove_recovery_temporary(backup)?;
+        let mut input = OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_NOFOLLOW)
+            .open(source)?;
+        let mode = input.metadata()?.mode() & 0o777;
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(backup)?;
+        if io::copy(
+            &mut Read::by_ref(&mut input).take(MAX_EXECUTABLE_BYTES + 1),
+            &mut output,
+        )? > MAX_EXECUTABLE_BYTES
+        {
+            return Err(io::Error::other(
+                "recovery backup exceeds the executable bound",
+            ));
+        }
+        output.sync_all()
+    }
+    fn rename(&self, from: &Path, to: &Path) -> io::Result<()> {
+        fs::rename(from, to)
+    }
+    fn remove_file(&self, path: &Path) -> io::Result<()> {
+        fs::remove_file(path)
+    }
+    fn sync_directory(&self, path: &Path) -> io::Result<()> {
+        sync_directory(path)
+    }
+}
+
+/// Reclaim only the reserved, private temporary file while holding recovery's lock.
+pub(crate) fn remove_recovery_temporary(path: &Path) -> io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.mode() & 0o022 != 0
+        || metadata.nlink() != 1
+        || metadata.len() > MAX_EXECUTABLE_BYTES
+    {
+        return Err(io::Error::other("unsafe recovery temporary file"));
+    }
+    fs::remove_file(path)
 }
 
 #[cfg(test)]
@@ -1612,6 +1740,34 @@ mod tests {
             b"/other/boomux\0daemon\0receive-handoff\0--channel\x00198\0",
             target
         ));
+    }
+
+    #[test]
+    fn recovery_replacement_rolls_back_without_linking_the_installed_file() {
+        let directory = temporary_directory();
+        let target = directory.join("boomux");
+        let candidate = directory.join("candidate");
+        fs::write(&target, b"old executable").unwrap();
+        fs::write(&candidate, b"new executable").unwrap();
+        let baseline = fingerprint(&target).unwrap();
+        let pinned = fingerprint(&candidate).unwrap();
+        let result = replace_with_rollback_using(
+            &RecoveryTransactionFs,
+            ReplacementTransaction {
+                target: &target,
+                candidate: &candidate,
+                baseline: &baseline,
+                candidate_fingerprint: &pinned,
+            },
+            || Err(io::Error::other("handoff failed")),
+            || Ok(()),
+            |_| {},
+        );
+        assert!(result.is_err());
+        assert_eq!(fs::read(&target).unwrap(), b"old executable");
+        assert_eq!(fs::metadata(&target).unwrap().nlink(), 1);
+        assert!(!directory.join(".boomux-recovery-backup").exists());
+        fs::remove_dir_all(directory).unwrap();
     }
 
     #[test]

--- a/tests/native_backend.rs
+++ b/tests/native_backend.rs
@@ -35,3 +35,6 @@ mod workspace_creation;
 
 #[path = "native_backend/git_work.rs"]
 mod git_work;
+
+#[path = "native_backend/remote_maintenance.rs"]
+mod remote_maintenance;

--- a/tests/native_backend/node_registration.rs
+++ b/tests/native_backend/node_registration.rs
@@ -864,7 +864,7 @@ fn registrations_survive_cold_recovery_outside_authoritative_state() {
 }
 
 #[test]
-fn node_upgrade_maintenance_blocks_registration_changes_until_release() {
+fn node_upgrade_maintenance_blocks_route_changes_but_allows_local_forget() {
     let daemon = TestDaemon::start_with(|command, runtime_dir| {
         let ssh = runtime_dir.join("ssh");
         fs::write(&ssh, "#!/bin/sh\nexit 64\n").unwrap();
@@ -899,7 +899,7 @@ fn node_upgrade_maintenance_blocks_registration_changes_until_release() {
     assert!(
         daemon
             .client
-            .forget_node_registration(&registration.node_id)
+            .rename_node_registration(&registration.node_id, "office", registration.revision)
             .is_err()
     );
     assert_eq!(
@@ -918,6 +918,24 @@ fn node_upgrade_maintenance_blocks_registration_changes_until_release() {
         .rename_node_registration(&registration.node_id, "office", registration.revision)
         .unwrap();
     assert_eq!(renamed.alias, "office");
+    let (_, token) = daemon
+        .client
+        .begin_node_upgrade_maintenance(&renamed.node_id, renamed.revision)
+        .unwrap();
+    let forgotten = daemon
+        .client
+        .forget_node_registration(&renamed.node_id)
+        .unwrap();
+    assert_eq!(forgotten.node_id, renamed.node_id);
+    assert_eq!(forgotten.tombstone_epoch, renamed.tombstone_epoch + 1);
+    assert!(daemon.client.node_registration(&renamed.node_id).is_err());
+    assert!(
+        daemon
+            .client
+            .finish_node_upgrade_maintenance(&renamed.node_id, token)
+            .is_err()
+    );
+    daemon.client.restart().unwrap();
 }
 
 #[test]

--- a/tests/native_backend/remote_bootstrap.rs
+++ b/tests/native_backend/remote_bootstrap.rs
@@ -923,6 +923,14 @@ fn registered_node_reauthentication_is_interactive_read_only_and_requests_projec
         String::from_utf8_lossy(&output)
             .contains("Authenticated work and requested a fresh background observation")
     );
+    let output = String::from_utf8_lossy(&output);
+    for stage in [
+        "15-second SSH connection timeout",
+        "SSH sign-in succeeded",
+        "Remote identity verified",
+    ] {
+        assert!(output.contains(stage), "missing progress stage: {stage}");
+    }
     assert_eq!(fs::read(&registration_path).unwrap(), registration_before);
     let ssh_log = fs::read_to_string(directory.join("ssh.log")).unwrap();
     for forbidden in [

--- a/tests/native_backend/remote_maintenance.rs
+++ b/tests/native_backend/remote_maintenance.rs
@@ -1,0 +1,278 @@
+use boomux::client::Client;
+use serde_json::{Value, json};
+#[cfg(target_os = "linux")]
+use std::process::Stdio;
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::PathBuf,
+    process::{Command, Output},
+};
+use uuid::Uuid;
+
+struct Fixture {
+    root: PathBuf,
+    node: String,
+    runner: PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!("boomux-recovery-{}", Uuid::new_v4()));
+        for directory in ["", "home", "state/boomux", "runtime/boomux", "config"] {
+            fs::create_dir_all(root.join(directory)).unwrap();
+            fs::set_permissions(root.join(directory), fs::Permissions::from_mode(0o700)).unwrap();
+        }
+        let node = Uuid::new_v4().to_string();
+        let identity = root.join("state/boomux/node.json");
+        fs::write(&identity, json!({"version":1,"node_id":node}).to_string()).unwrap();
+        fs::set_permissions(identity, fs::Permissions::from_mode(0o600)).unwrap();
+        let runner = root.join("runner");
+        fs::copy(env!("CARGO_BIN_EXE_boomux"), &runner).unwrap();
+        Self { root, node, runner }
+    }
+    fn command(&self) -> Command {
+        self.command_at(&self.runner)
+    }
+    fn command_at(&self, executable: &std::path::Path) -> Command {
+        let mut cmd = Command::new(executable);
+        cmd.env("HOME", self.root.join("home"))
+            .env("XDG_RUNTIME_DIR", self.root.join("runtime"))
+            .env("XDG_STATE_HOME", self.root.join("state"))
+            .env("BOOMUX_STATE_HOME", self.root.join("state"))
+            .env("XDG_CONFIG_HOME", self.root.join("config"))
+            .env("SHELL", "/bin/sh");
+        cmd
+    }
+    fn installed(&self) -> PathBuf {
+        self.root.join("home/.local/bin/boomux")
+    }
+    fn probe(&self) -> Value {
+        let out = self
+            .command()
+            .args(["__remote-maintenance", "probe", &self.node])
+            .output()
+            .unwrap();
+        success(&out);
+        serde_json::from_slice(&out.stdout).unwrap()
+    }
+    fn action(&self, action: &str, probe: &Value) -> Output {
+        self.command()
+            .args([
+                "__remote-maintenance",
+                action,
+                &self.node,
+                probe["token"].as_str().unwrap(),
+            ])
+            .output()
+            .unwrap()
+    }
+    fn client(&self) -> Client {
+        Client::from_socket_path(self.root.join("runtime/boomux/daemon.sock"))
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = self.client().shutdown_if_node_identity(&self.node);
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+fn success(out: &Output) {
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+#[test]
+fn missing_executable_can_be_repaired_and_removal_is_repeatable() {
+    let fixture = Fixture::new();
+    fs::remove_dir(fixture.root.join("runtime/boomux")).unwrap();
+    let saved = fixture.root.join("state/boomux/user-data");
+    fs::write(&saved, b"preserve").unwrap();
+    let probe = fixture.probe();
+    assert!(probe["probe"]["installed"].is_null());
+    assert!(!fixture.root.join("runtime/boomux/daemon.sock").exists());
+    success(&fixture.action("repair", &probe));
+    assert!(fixture.installed().is_file());
+    assert_eq!(fixture.probe()["probe"]["node_id"], fixture.node);
+    success(&fixture.action("remove", &fixture.probe()));
+    assert!(!fixture.installed().exists());
+    success(&fixture.action("remove", &fixture.probe()));
+    assert_eq!(fs::read(saved).unwrap(), b"preserve");
+    assert!(
+        !fixture
+            .root
+            .join("home/.local/bin/.boomux.bootstrap.lock")
+            .exists()
+    );
+}
+
+#[test]
+fn changed_identity_and_changed_executable_refuse_mutation() {
+    let fixture = Fixture::new();
+    let out = fixture
+        .command()
+        .args(["__remote-maintenance", "probe", &Uuid::new_v4().to_string()])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(!fixture.installed().exists());
+    let probe = fixture.probe();
+    fs::create_dir_all(fixture.installed().parent().unwrap()).unwrap();
+    fs::write(fixture.installed(), b"concurrent install").unwrap();
+    let out = fixture.action("remove", &probe);
+    assert!(!out.status.success());
+    assert_eq!(
+        fs::read(fixture.installed()).unwrap(),
+        b"concurrent install"
+    );
+}
+
+#[test]
+fn abandoned_recovery_lock_is_reclaimed_but_legacy_transaction_is_preserved() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.installed().parent().unwrap()).unwrap();
+    let lock = fixture.installed().with_file_name(".boomux.bootstrap.lock");
+    fs::create_dir(&lock).unwrap();
+    fs::write(lock.join("id"), b"legacy transaction").unwrap();
+    assert!(!fixture.action("remove", &fixture.probe()).status.success());
+    assert_eq!(fs::read(lock.join("id")).unwrap(), b"legacy transaction");
+    fs::remove_dir_all(&lock).unwrap();
+    fs::write(&lock, b"boomux-recovery-v1\n").unwrap();
+    fs::set_permissions(&lock, fs::Permissions::from_mode(0o600)).unwrap();
+    use std::os::fd::AsRawFd;
+    let held = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&lock)
+        .unwrap();
+    assert_eq!(
+        unsafe { libc::flock(held.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) },
+        0
+    );
+    assert!(!fixture.action("remove", &fixture.probe()).status.success());
+    assert!(lock.exists());
+    drop(held);
+    success(&fixture.action("remove", &fixture.probe()));
+    assert!(!lock.exists());
+}
+
+#[test]
+fn stale_daemon_socket_does_not_block_missing_executable_removal() {
+    let fixture = Fixture::new();
+    let socket = fixture.root.join("runtime/boomux/daemon.sock");
+    let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+    drop(listener);
+    assert!(fixture.probe()["probe"]["daemon_pid"].is_null());
+    success(&fixture.action("remove", &fixture.probe()));
+}
+
+#[test]
+fn recovery_refuses_symlink_installation_parent() {
+    let fixture = Fixture::new();
+    fs::create_dir_all(fixture.root.join("home/.local")).unwrap();
+    std::os::unix::fs::symlink(
+        fixture.root.join("config"),
+        fixture.root.join("home/.local/bin"),
+    )
+    .unwrap();
+    let out = fixture
+        .command()
+        .args(["__remote-maintenance", "probe", &fixture.node])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    assert!(!fixture.root.join("config/boomux").exists());
+}
+
+#[test]
+fn unreadable_saved_state_prevents_repair_but_does_not_prevent_removal() {
+    let fixture = Fixture::new();
+    let state = fixture.root.join("state/boomux/state.json");
+    fs::write(&state, b"{\"version\":999}").unwrap();
+    fs::set_permissions(&state, fs::Permissions::from_mode(0o600)).unwrap();
+    let out = fixture.action("repair", &fixture.probe());
+    assert!(!out.status.success());
+    assert!(!fixture.installed().exists());
+    assert!(String::from_utf8_lossy(&out.stderr).contains("saved remote state cannot be read"));
+    success(&fixture.action("remove", &fixture.probe()));
+    assert_eq!(fs::read(&state).unwrap(), b"{\"version\":999}");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn recovery_follows_running_user_installation_and_preserves_shell_run() {
+    use crate::support::{profile, wait_until};
+    use boomux::protocol::ShellSpec;
+    let fixture = Fixture::new();
+    let installed = fixture.root.join("home/custom/bin/boomux");
+    fs::create_dir_all(installed.parent().unwrap()).unwrap();
+    fs::copy(&fixture.runner, &installed).unwrap();
+    let mut child = fixture
+        .command_at(&installed)
+        .args(["daemon", "run"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let client = fixture.client();
+    wait_until(
+        || client.ping().is_ok(),
+        "recovery fixture daemon did not start",
+    );
+    let workspace = client
+        .create_workspace(
+            "keep",
+            vec![ShellSpec {
+                name: "keep".into(),
+                command: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    "echo $$ > shell.pid; exec /bin/sleep 300".into(),
+                ],
+                cwd: fixture.root.clone(),
+            }],
+        )
+        .unwrap();
+    let shell = &workspace.shells[0].id;
+    let attachment = client.attach(shell, false, profile()).unwrap();
+    let run = client.get_shell(shell).unwrap().run.unwrap();
+    drop(attachment);
+    wait_until(
+        || fixture.root.join("shell.pid").exists(),
+        "Shell PID was not recorded",
+    );
+    let shell_pid: i32 = fs::read_to_string(fixture.root.join("shell.pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    let old_pid = client.daemon_process_credentials().unwrap().pid;
+    // First replace an existing executable at a noncanonical user path.
+    let probe = fixture.probe();
+    assert_eq!(probe["probe"]["destination"], installed.to_str().unwrap());
+    success(&fixture.action("repair", &probe));
+    assert_ne!(client.daemon_process_credentials().unwrap().pid, old_pid);
+    assert_eq!(client.get_shell(shell).unwrap().run.unwrap().id, run.id);
+    // Then repair the same running owner after its on-disk executable disappears.
+    fs::remove_file(&installed).unwrap();
+    success(&fixture.action("repair", &fixture.probe()));
+    assert_eq!(client.get_shell(shell).unwrap().run.unwrap().id, run.id);
+    assert_eq!(client.node_identity().unwrap(), fixture.node);
+    assert_eq!(unsafe { libc::kill(shell_pid, 0) }, 0);
+    assert!(
+        client
+            .get_shell(shell)
+            .unwrap()
+            .run
+            .unwrap()
+            .ended_at_ms
+            .is_none()
+    );
+    success(&fixture.action("remove", &fixture.probe()));
+    assert!(!installed.exists());
+    assert!(client.ping().is_err());
+    let _ = child.wait();
+}


### PR DESCRIPTION
Remote maintenance could require reinstalling the executable before uninstalling it, reject a valid user installation because of its path, or strand the local connection behind a failed update's maintenance lease. Update and removal now have an identity-pinned recovery path that works with a missing CLI and discovers a running owner's actual user installation. Local Forget connection remains available during maintenance.

- Stage a temporary recovery helper using the existing verified install source. Inspect the saved Node identity without creating a new identity or daemon; revalidate the installation at confirmation and serialize recovery against other recovery and legacy update operations.
- Repair missing executables with atomic no-replace installation. Update custom user paths with a copied rollback backup, verify the actual executable after handoff, and retain saved Workspace data. Record the verified installation path in a separate owner-only version-1 receipt. Package-managed and Desktop-bundled installations retain installer ownership.
- Make removal tolerate an absent executable, missing runtime directory, stale socket, unfamiliar integration names, and failed optional integration cleanup. Preserve modified or unrecognized assets and incompatible saved state. Preserve maintenance admission if local forget cannot persist.
- Bound SSH connection establishment to 15 seconds with one attempt, show sign-in/verification progress, report remaining maintenance lease time, and preserve explicit upload-lock refusals instead of reporting an unknown outcome.
- Add Desktop Hide from sidebar and Show for unavailable remote Workspaces. This is local presentation state; permanent remote deletion still requires connectivity. Layout schema 2 explicitly migrates schema 1. No daemon-state or wire-version change.

Validation:
- Root and Desktop cargo checks passed.
- Seven focused native recovery scenarios passed, including a real Linux daemon at a custom path, repair after executable deletion, preserved Shell process/run, repeated removal, stale runtime state, identity/file changes, ownership guards, and held/abandoned locks.
- 25 update/rollback unit tests passed, including copied-backup rollback.
- Focused registration and failed-forget persistence tests passed.
- Ten explicit SSH upgrade/uninstall tests, real staging/expiration shell fixture, and CLI descriptor test passed.
- Earlier focused sign-in transport, native reauthentication, and Desktop layout migration/hide/restore checks passed. Formatting and diff checks passed.

Full selected CI remains required before merge. No live remote installation was changed by this implementation work. macOS recovery and live mixed-version protocol-52 handoff remain unvalidated; protocol-46 owners retain the documented cold-upgrade guard. Cross-platform recovery needs a published binary that includes the new helper workflow.
