### PR TITLE
fix(desktop): prioritize rename dialogs over panel keyboard input

### DIFF
--- a/desktop/src/input_routing.rs
+++ b/desktop/src/input_routing.rs
@@ -1,0 +1,122 @@
+//! Resolve one keyboard recipient for overlapping Desktop surfaces.
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct InputOverlays {
+    pub resource_dialog: bool,
+    pub remote_picker: bool,
+    pub project_search: bool,
+    pub git_search: bool,
+    pub remotes: bool,
+    pub settings_restart: bool,
+    pub settings_input: bool,
+    pub help: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InputTarget {
+    ResourceDialog,
+    RemotePicker,
+    ProjectSearch,
+    GitSearch,
+    Remotes,
+    SettingsRestart,
+    SettingsInput,
+    Help,
+    Workspace,
+}
+
+impl InputOverlays {
+    pub fn target(self) -> InputTarget {
+        use InputTarget::*;
+        [
+            (self.resource_dialog, ResourceDialog),
+            (self.remote_picker, RemotePicker),
+            (self.project_search, ProjectSearch),
+            (self.git_search, GitSearch),
+            (self.remotes, Remotes),
+            (self.settings_restart, SettingsRestart),
+            (self.settings_input, SettingsInput),
+            (self.help, Help),
+        ]
+        .into_iter()
+        .find_map(|(active, target)| active.then_some(target))
+        .unwrap_or(Workspace)
+    }
+}
+
+impl InputTarget {
+    pub fn key_context(self, workspace_context: &'static str) -> &'static str {
+        match self {
+            Self::ResourceDialog => "ResourceDialog",
+            Self::Help => "Help",
+            Self::Workspace => workspace_context,
+            _ => "BoomuxSettingsInput",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_dialog_owns_typing_with_any_underlying_panel() {
+        for panel in [
+            InputOverlays {
+                remotes: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                remote_picker: true,
+                project_search: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                project_search: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                git_search: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                settings_restart: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                settings_input: true,
+                ..Default::default()
+            },
+            InputOverlays {
+                help: true,
+                ..Default::default()
+            },
+            InputOverlays::default(),
+        ] {
+            let modal = InputOverlays {
+                resource_dialog: true,
+                ..panel
+            };
+            assert_eq!(modal.target(), InputTarget::ResourceDialog);
+            for base in ["Terminal", "Layout", "Sidebar", "SidebarLayout"] {
+                assert_eq!(modal.target().key_context(base), "ResourceDialog");
+            }
+            assert_ne!(panel.target(), InputTarget::ResourceDialog);
+        }
+    }
+
+    #[test]
+    fn dismissing_dialog_returns_keyboard_to_the_open_remotes_panel() {
+        let mut state = InputOverlays {
+            resource_dialog: true,
+            remotes: true,
+            ..Default::default()
+        };
+        assert_eq!(state.target(), InputTarget::ResourceDialog);
+        state.resource_dialog = false;
+        assert_eq!(state.target(), InputTarget::Remotes);
+        assert_eq!(state.target().key_context("Sidebar"), "BoomuxSettingsInput");
+        state.remotes = false;
+        assert_eq!(state.target().key_context("SidebarLayout"), "SidebarLayout");
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -3,6 +3,7 @@ mod bundle_update;
 mod project_search;
 use boomux::generated_names;
 mod git_panel;
+mod input_routing;
 mod layout;
 mod layout_badge;
 mod layout_persistence;
@@ -30,6 +31,7 @@ use gpui::{
     UnderlineStyle, Window, WindowBounds, WindowOptions, actions, canvas, div, ease_out_quint,
     fill, font, point, prelude::*, px, relative, rgb_to_hsla, rgba, size,
 };
+use input_routing::{InputOverlays, InputTarget};
 use layout::{Axis, Direction, Node, Rect};
 use terminal::{
     AgentChoice, BoomuxOverview, ShellChoice, TerminalImagePlacement, TerminalScreen,
@@ -4316,6 +4318,15 @@ impl Workspace {
 
     fn paste_clipboard(&mut self, _: &PasteClipboard, _: &mut Window, cx: &mut Context<Self>) {
         if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+            if let Some(dialog) = self.resource_dialog.as_mut() {
+                if dialog.kind == ResourceDialogKind::Rename && !dialog.busy {
+                    append_resource_name(&mut dialog.value, &text);
+                    dialog.error = None;
+                }
+                cx.stop_propagation();
+                cx.notify();
+                return;
+            }
             if self.project_menu_open {
                 if !self.remote_picker_open {
                     project_search::append(&mut self.project_search, &text);
@@ -4330,19 +4341,7 @@ impl Workspace {
                 cx.notify();
                 return;
             }
-            if let Some(ResourceDialog {
-                kind: ResourceDialogKind::Rename,
-                value,
-                busy: false,
-                ..
-            }) = self.resource_dialog.as_mut()
-            {
-                append_resource_name(value, &text);
-                cx.stop_propagation();
-                cx.notify();
-            } else {
-                self.paste_into_focused(&text, cx);
-            }
+            self.paste_into_focused(&text, cx);
         }
     }
 
@@ -4944,12 +4943,31 @@ impl Workspace {
         }
     }
 
+    fn keyboard_input_target(&self) -> InputTarget {
+        InputOverlays {
+            resource_dialog: self.resource_dialog.is_some(),
+            remote_picker: self.project_menu_open && self.remote_picker_open,
+            project_search: self.project_menu_open,
+            git_search: self.git_panel.search_focused,
+            remotes: self.nodes_open && self.navigation_region == NavigationRegion::Sidebar,
+            settings_restart: self.settings_restart_confirm,
+            settings_input: self.boomux_setting_input.is_some(),
+            help: self.help_open,
+        }
+        .target()
+    }
+
     fn terminal_key_down(
         &mut self,
         event: &KeyDownEvent,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let input_target = self.keyboard_input_target();
+        if input_target == InputTarget::ResourceDialog {
+            self.resource_dialog_key_down(event, window, cx);
+            return;
+        }
         if event.keystroke.key == "space" && self.layout_leader_pressed_at.is_some() {
             self.layout_leader_release_task = None;
             cx.stop_propagation();
@@ -4964,7 +4982,7 @@ impl Workspace {
         } else if !event.is_held {
             self.layout_suppressed_keys.remove(&event.keystroke.key);
         }
-        if self.project_menu_open && self.remote_picker_open {
+        if input_target == InputTarget::RemotePicker {
             let modifiers = event.keystroke.modifiers;
             if modifiers.control || modifiers.alt || modifiers.platform || modifiers.function {
                 cx.stop_propagation();
@@ -5009,7 +5027,7 @@ impl Workspace {
             cx.notify();
             return;
         }
-        if self.project_menu_open {
+        if input_target == InputTarget::ProjectSearch {
             match event.keystroke.key.as_str() {
                 "escape" => self.project_menu_open = false,
                 "backspace" => {
@@ -5035,7 +5053,7 @@ impl Workspace {
             cx.notify();
             return;
         }
-        if self.git_panel.search_focused {
+        if input_target == InputTarget::GitSearch {
             match event.keystroke.key.as_str() {
                 "escape" | "enter" => self.git_panel.search_focused = false,
                 "backspace" => {
@@ -5058,7 +5076,7 @@ impl Workspace {
             return;
         }
 
-        if self.nodes_open && self.navigation_region == NavigationRegion::Sidebar {
+        if input_target == InputTarget::Remotes {
             let modifiers = event.keystroke.modifiers;
             if modifiers.control
                 || modifiers.alt
@@ -5112,7 +5130,7 @@ impl Workspace {
             cx.stop_propagation();
             return;
         }
-        if self.settings_restart_confirm {
+        if input_target == InputTarget::SettingsRestart {
             if event.keystroke.key == "escape" {
                 self.settings_restart_confirm = false;
                 cx.notify();
@@ -5120,16 +5138,12 @@ impl Workspace {
             cx.stop_propagation();
             return;
         }
-        if self.boomux_setting_input.is_some() {
+        if input_target == InputTarget::SettingsInput {
             self.boomux_setting_key_down(event, cx);
             return;
         }
-        if self.help_open {
+        if input_target == InputTarget::Help {
             self.help_key_down(event, cx);
-            return;
-        }
-        if self.resource_dialog.is_some() {
-            self.resource_dialog_key_down(event, window, cx);
             return;
         }
         if self.settings_open && event.keystroke.key == "escape" {
@@ -10704,16 +10718,12 @@ impl Render for Workspace {
             })
             .track_focus(&self.focus_handle)
             .key_context(
-                if (self.nodes_open && self.navigation_region == NavigationRegion::Sidebar)
-                    || self.git_panel.search_focused
-                    || self.project_menu_open
-                    || self.boomux_setting_input.is_some()
-                    || self.settings_restart_confirm
-                {
-                    "BoomuxSettingsInput"
-                } else {
-                    workspace_key_context(self.help_open, self.navigation_region, self.layout_mode)
-                },
+                self.keyboard_input_target()
+                    .key_context(workspace_key_context(
+                        self.help_open,
+                        self.navigation_region,
+                        self.layout_mode,
+                    )),
             )
             .on_action(cx.listener(Self::focus_left))
             .on_action(cx.listener(Self::focus_right))
@@ -10794,9 +10804,9 @@ impl Render for Workspace {
             .text_color(rgb(0xcdd6f4))
             .child(content)
             .when_some(sidebar_menu, |element, menu| element.child(menu))
-            .when_some(resource_dialog, |element, dialog| element.child(dialog))
             .when_some(settings_restart, |element, dialog| element.child(dialog))
             .when_some(help, |element, help| element.child(help))
+            .when_some(resource_dialog, |element, dialog| element.child(dialog))
     }
 }
 
@@ -11373,6 +11383,9 @@ fn main() {
             KeyBinding::new("secondary-shift-c", CopySelection, Some("Layout")),
             KeyBinding::new("secondary-shift-c", CopySelection, Some("Sidebar")),
             KeyBinding::new("secondary-shift-c", CopySelection, Some("SidebarLayout")),
+            KeyBinding::new("secondary-v", PasteClipboard, Some("ResourceDialog")),
+            KeyBinding::new("secondary-shift-v", PasteClipboard, Some("ResourceDialog")),
+            KeyBinding::new("shift-insert", PasteClipboard, Some("ResourceDialog")),
             KeyBinding::new("secondary-shift-v", PasteClipboard, Some("Terminal")),
             KeyBinding::new("secondary-shift-v", PasteClipboard, Some("Layout")),
             KeyBinding::new("secondary-shift-v", PasteClipboard, Some("Sidebar")),

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -70,6 +70,13 @@ handler. Future button forwarding must preserve exclusive gesture ownership.
 
 ### Input And Layout Mode
 
+Rename and removal dialogs own keyboard input while open, even when the Remotes,
+project, or Git panel remains open behind them. The shared input router gives
+these modals a dedicated `ResourceDialog` key context before panel navigation or
+layout-leader handling. Clipboard paste goes to an editable rename field and is
+consumed by busy or confirmation-only dialogs. Closing the modal restores the
+underlying panel's routing without changing its expanded state.
+
 GPUI key contexts separate ordinary terminal input from desktop layout actions.
 The default `Terminal` context reserves only explicit lifecycle, clipboard, and
 mode-entry commands; other keys reach the pane encoder. `Ctrl+Space` activates
@@ -108,6 +115,7 @@ and history but does not remove project shortcuts or filesystem contents.
 
 ## Module Map
 
+- `src/input_routing.rs`: keyboard recipient priority and modal key contexts.
 - `src/main.rs`: application model, Boomux sidebar projection, input routing,
   pane lifecycle, GPUI elements, terminal cell drawing, and GPU image caching.
 - `src/layout.rs`: binary split tree, normalized rectangles, spatial focus,


### PR DESCRIPTION
With the Remotes panel open and the sidebar active, its keyboard handler consumed input before the rename dialog could receive it. Connection, Shell, and Workspace rename fields appeared focused but could not be edited; Enter and Escape could act on the panel underneath.

Resolve the keyboard recipient once, prioritizing rename/removal dialogs over underlying panels and layout handling. Give these dialogs a dedicated key context so terminal and layout shortcuts do not intercept typing. Route clipboard paste to the modal first, including consuming it while busy or confirming removal, and keep the modal above other overlays. Closing it preserves the underlying panel's expanded state and restores its keyboard routing.

Validation:
- Desktop `cargo check -p boomux-desktop --locked` passed using the existing local build cache.
- Two focused input-routing regression tests passed, covering all underlying panels, terminal/sidebar/layout contexts, and return to Remotes after dismissal. The tests were run directly with `rustc --test desktop/src/input_routing.rs`; CI also includes them in the Desktop suite.
- Formatting and diff checks passed. No hands-on GUI verification yet; complete Desktop validation remains with PR CI.
