### PR TITLE
fix(remote): allow immediate reinstall and preserve workspaces during setup

### DIFF
--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -77,6 +77,21 @@ fn decode_tree(node: &Tree, ids: &HashMap<u64, usize>) -> Node {
         },
     }
 }
+impl TerminalPane {
+    fn saved_reference(&self) -> Option<Pane> {
+        if self.temporary_setup || self.shell.as_ref().is_some_and(|shell| shell.desktop_setup) {
+            return None;
+        }
+        self.shell
+            .as_ref()
+            .map(|shell| Pane {
+                shell: Some(shell.id.clone()),
+                workspace: Some(shell.workspace_id.clone()),
+            })
+            .or_else(|| self.restored.clone())
+    }
+}
+
 impl Workspace {
     pub(super) fn initialize_layout(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.sidebar_viewport_width = f32::from(window.viewport_size().width);
@@ -155,12 +170,8 @@ impl Workspace {
         } else {
             self.terminals
                 .get(&self.focused)
-                .and_then(|p| {
-                    p.shell
-                        .as_ref()
-                        .map(|s| s.workspace_id.clone())
-                        .or_else(|| p.restored.as_ref().and_then(|p| p.workspace.clone()))
-                })
+                .and_then(TerminalPane::saved_reference)
+                .and_then(|pane| pane.workspace)
                 .map(|w| format!("workspace:{w}"))
                 .unwrap_or_else(|| self.layout_document.active.clone())
         };
@@ -172,18 +183,10 @@ impl Workspace {
             .iter()
             .filter_map(|id| {
                 self.terminals.get(id).map(|pane| {
-                    let reference = pane
-                        .shell
-                        .as_ref()
-                        .map(|shell| Pane {
-                            shell: Some(shell.id.clone()),
-                            workspace: Some(shell.workspace_id.clone()),
-                        })
-                        .or_else(|| pane.restored.clone())
-                        .unwrap_or(Pane {
-                            shell: None,
-                            workspace: None,
-                        });
+                    let reference = pane.saved_reference().unwrap_or(Pane {
+                        shell: None,
+                        workspace: None,
+                    });
                     (*id as u64, reference)
                 })
             })
@@ -631,6 +634,53 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn setup_overlay_does_not_replace_saved_workspace_or_panes() {
+        let reference = Pane {
+            shell: Some("original-shell".into()),
+            workspace: Some("original-workspace".into()),
+        };
+        let mut pane = TerminalPane {
+            restored: Some(reference.clone()),
+            ..Default::default()
+        };
+        assert_eq!(
+            pane.saved_reference().unwrap().workspace,
+            reference.workspace
+        );
+        pane.temporary_setup = true;
+        assert!(pane.saved_reference().is_none());
+        // Saving while setup has focus must prune only the overlay and retain
+        // the underlying tiled geometry, identity, and maximized state.
+        let mut arrangement = Arrangement {
+            tree: Some(Tree::Pane(1)),
+            floating: vec![Floating {
+                pane: 2,
+                rect: [10.0, 10.0, 500.0, 400.0],
+            }],
+            panes: [
+                (1, reference),
+                (
+                    2,
+                    pane.saved_reference().unwrap_or(Pane {
+                        shell: None,
+                        workspace: None,
+                    }),
+                ),
+            ]
+            .into(),
+            focused: Some(2),
+            expanded: Some(1),
+            canvas: [1200.0, 800.0],
+        };
+        arrangement.discard_unbound_panes();
+        assert!(matches!(arrangement.tree, Some(Tree::Pane(1))));
+        assert!(arrangement.floating.is_empty());
+        assert_eq!(arrangement.panes.len(), 1);
+        assert_eq!(arrangement.focused, Some(1));
+        assert_eq!(arrangement.expanded, Some(1));
+    }
+
     #[test]
     fn layout_reuse_requires_the_same_owner_shell_and_running_instance() {
         let current = ShellChoice {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1660,6 +1660,7 @@ struct Workspace {
 
 #[derive(Default)]
 struct TerminalPane {
+    temporary_setup: bool,
     shell: Option<ShellChoice>,
     restored: Option<layout_state::Pane>,
     restore_attempt: Option<String>,
@@ -3598,7 +3599,9 @@ impl Workspace {
     }
 
     fn focus_after_removal(&mut self) {
-        if let Some(pane) = self.floating.last() {
+        if let Some(id) = self.fullscreen.filter(|id| self.terminals.contains_key(id)) {
+            self.focused = id;
+        } else if let Some(pane) = self.floating.last() {
             self.focused = pane.id;
         } else if let Some(layout) = &self.layout {
             self.focused = layout.pane_ids()[0];
@@ -3913,7 +3916,12 @@ impl Workspace {
             return;
         }
         // Keep the dragged pane focused even while it crosses other panes.
-        if self.fullscreen.is_some_and(|expanded| expanded != id) {
+        if self.fullscreen.is_some_and(|expanded| expanded != id)
+            && !self
+                .terminals
+                .get(&id)
+                .is_some_and(|pane| pane.temporary_setup)
+        {
             return;
         }
         if !self
@@ -5505,12 +5513,35 @@ impl Workspace {
     ) {
         self.sidebar_menu = None;
         self.navigation_region = NavigationRegion::Terminal;
-        self.fullscreen = None;
-        self.layout_animation = None;
-        if self.workspace_pane_mode == WorkspacePaneMode::Workspace {
-            self.detach_all_panes(window);
+        let temporary_setup = launch.temporary_setup();
+        if !temporary_setup {
+            self.fullscreen = None;
+            self.layout_animation = None;
         }
-        let pane_id = self.insert_pane();
+        let pane_id = if temporary_setup {
+            // A setup terminal is an overlay, not navigation to another Workspace.
+            self.capture_arrangement();
+            let id = self.next_id;
+            self.next_id += 1;
+            self.terminals.insert(
+                id,
+                TerminalPane {
+                    temporary_setup: true,
+                    ..TerminalPane::default()
+                },
+            );
+            self.floating.push(centered_floating_pane(
+                id,
+                self.panel_size(window),
+                self.pane_gap,
+            ));
+            id
+        } else {
+            if self.workspace_pane_mode == WorkspacePaneMode::Workspace {
+                self.detach_all_panes(window);
+            }
+            self.insert_pane()
+        };
         self.focused = pane_id;
         let size = self.terminal_grid_size(pane_id, window);
         if let Some(pane) = self.terminals.get_mut(&pane_id) {
@@ -5573,11 +5604,13 @@ impl Workspace {
                         pane.screen = Some(session.screen());
                         pane.shell = Some(shell);
                         pane.session = Some(session);
-                        reveal_opened_workspace(
-                            this.workspace_pane_mode,
-                            &mut this.expanded_workspaces,
-                            &workspace_id,
-                        );
+                        if !temporary_setup {
+                            reveal_opened_workspace(
+                                this.workspace_pane_mode,
+                                &mut this.expanded_workspaces,
+                                &workspace_id,
+                            );
+                        }
                         if !this.workspace_order.contains(&workspace_id) {
                             this.workspace_order.push(workspace_id.clone());
                         }
@@ -10388,10 +10421,21 @@ impl Render for Workspace {
                 .as_ref()
                 .is_some_and(|layout| layout.contains(id))
             {
-                // A maximized tiled pane covers the floating layer as well.
-                floating_panes.clear();
+                // Setup overlays remain usable without unmaximizing the current pane.
+                floating_panes.retain(|pane| {
+                    self.terminals
+                        .get(&pane.id)
+                        .is_some_and(|terminal| terminal.temporary_setup)
+                });
             } else {
-                floating_panes.sort_by_key(|pane| pane.id == id);
+                floating_panes.sort_by_key(|pane| {
+                    (
+                        self.terminals
+                            .get(&pane.id)
+                            .is_some_and(|terminal| terminal.temporary_setup),
+                        pane.id == id,
+                    )
+                });
             }
         }
         let floating = floating_panes

--- a/desktop/src/terminal.rs
+++ b/desktop/src/terminal.rs
@@ -1229,7 +1229,7 @@ pub enum WorkspaceLaunch {
 }
 
 impl WorkspaceLaunch {
-    fn temporary_setup(&self) -> bool {
+    pub(crate) fn temporary_setup(&self) -> bool {
         matches!(
             self,
             Self::Setup

--- a/docs/desktop/architecture.md
+++ b/docs/desktop/architecture.md
@@ -266,6 +266,11 @@ Workspace authority.
 
 ## Remote Node Entry Points
 
+Connection, sign-in, update, uninstall, and agent setup terminals open as temporary
+floating panes over the current arrangement. They do not detach existing panes,
+change the expanded Workspace, or enter the saved arrangement. Closing a failed
+or cancelled setup leaves the underlying panes available.
+
 The lower sidebar has Agents, Git, and Remotes tabs. Remotes contains the scrollable
 machine cards with selected-machine details and create/update/sign-in controls.
 The general connect action sits above the cards, outside any machine's controls;
@@ -280,8 +285,9 @@ use the registered owner's existing guarded APIs. Cached directories are not
 invented from local paths. Remote creation resolves the owner's starting directory
 and creates the owner-local Workspace and first pending Shell with fresh exact IDs;
 ambiguous mutation failures are surfaced without automatic replay.
-The initial connect flow attempts to create this Workspace after successful
-registration. An owner-confirmed `already_exists` result leaves the connection
+The initial connect flow reads the verified owner's live Workspace snapshot after
+registration and offers a starter only when the owner has no Workspaces. Reconnecting
+with a different connection alias does not create an additional Workspace. An owner-confirmed `already_exists` result leaves the connection
 successful and directs the user to existing Workspaces in the sidebar, without
 selecting or modifying one by name. Other failures remain errors and are not
 replayed. When creation succeeds, Desktop opens its exact Shell after the user

--- a/docs/remote-nodes.md
+++ b/docs/remote-nodes.md
@@ -1152,11 +1152,14 @@ requires connectivity. **Forget connection only** on the machine card removes
 all that machine's cached entries and its local registration without contacting
 the owner. These operations have distinct scopes.
 
-A completed remote update retains its transaction lock and rollback files for
-up to three minutes while watchdog cleanup finishes. Another update during
-that window returns `busy` before uploading or replacing anything. This explicit
-refusal releases the attempted update's local maintenance window; it must not
-be presented as an unknown upgrade outcome. Wait for cleanup before retrying.
+After receiving a successful install/update commit acknowledgement, the coordinator
+promptly releases the exact transaction lock and rollback files. Cleanup claims
+and retires only that committed transaction; delayed cleanup cannot remove a
+new install's lock. This allows immediate uninstall and reinstall. If the final
+cleanup exchange is interrupted, the watchdog remains the bounded fallback
+(up to three minutes). An active or recovering transaction still returns `busy`
+before another upload or replacement. This explicit refusal releases the attempted
+update's local maintenance window and is not an unknown upgrade outcome.
 
 An ambiguous update failure can retain a separate local Node maintenance lease
 for up to ten minutes after its last renewal. This is distinct from the remote

--- a/src/main.rs
+++ b/src/main.rs
@@ -2531,7 +2531,7 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
                 );
             }
             let (alias, target) = resolve_node_add_inputs(alias, target, json)?;
-            let remote = verified_remote_connection(&target, !json)?;
+            let mut remote = verified_remote_connection(&target, !json)?;
             let registration = client::connect_or_start()?.add_node_registration(
                 alias,
                 target,
@@ -2539,6 +2539,13 @@ fn node_command(command: NodeCommands, json: bool) -> Result<(), Box<dyn Error>>
             )?;
             print_node_registration(CommandKey::NodeAdd, &registration, json)?;
             if desktop_workspace {
+                if remote.has_workspaces(Duration::from_secs(15))? {
+                    println!(
+                        "Connected to {}. Existing remote Workspaces are available in the Desktop sidebar; no starter Workspace was created.",
+                        registration.alias
+                    );
+                    return Ok(());
+                }
                 let Some(shell) = client::connect_or_start()?
                     .create_initial_remote_workspace(&registration.node_id, &registration.alias)?
                 else {

--- a/src/ssh_bootstrap.rs
+++ b/src/ssh_bootstrap.rs
@@ -163,6 +163,14 @@ const REMOTE_INSTALL_COMMIT_COMMAND: &str = concat!(
     remote_process_identity_function!(),
     "if [ -d \"$committed\" ]; then printf 'boomux-install-commit-v1\\0committed\\0'; exit; fi; claim_acquire || exit 73; trap claim_release EXIT HUP INT TERM; if [ -d \"$committed\" ]; then :; elif [ -d \"$transaction\" ]; then /bin/mv \"$transaction\" \"$committed\"; else exit 1; fi; trap - EXIT HUP INT TERM; claim_release; printf 'boomux-install-commit-v1\\0committed\\0'"
 );
+// Called only after the coordinator has received the commit acknowledgement.
+// Retire the claimed directory before deleting it so delayed cleanup cannot
+// remove a new install's lock at the same canonical path.
+const REMOTE_INSTALL_FINALIZE_COMMAND: &str = concat!(
+    "PATH=/usr/bin:/bin; export PATH; set -eu; IFS= read -r txn; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; ",
+    remote_claim_functions!(),
+    "[ \"$(/bin/cat \"$lock/id\" 2>/dev/null || true)\" = \"$txn\" ] || exit 0; [ -d \"$lock/committed\" ] || exit 73; claim_acquire || exit 73; trap claim_release EXIT HUP INT TERM; [ \"$(/bin/cat \"$lock/id\")\" = \"$txn\" ]; [ -d \"$lock/committed\" ]; [ ! -e \"$transaction\" ] && [ ! -L \"$transaction\" ]; watchdog=$(/bin/cat \"$lock/committed/watchdog_pid\"); watchdog_start=$(/bin/cat \"$lock/committed/watchdog_start\"); case \"$watchdog\" in ''|*[!0-9]*) exit 1 ;; esac; [ \"$watchdog\" -gt 1 ]; current_start=$(claim_process_start \"$watchdog\" 2>/dev/null || true); /bin/mv \"$lock\" \"$transaction\"; trap '/bin/rm -rf \"$transaction\"' EXIT HUP INT TERM; /bin/rm -rf \"$transaction\"; trap - EXIT HUP INT TERM; if [ -n \"$watchdog_start\" ] && [ \"$current_start\" = \"$watchdog_start\" ]; then /bin/kill \"$watchdog\" 2>/dev/null || true; fi"
+);
 #[doc(hidden)]
 pub const REMOTE_INSTALL_MARK_RESTARTED_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(cat \"$lock/id\")\" = \"$txn\" ]; : > \"$transaction/restarted\"";
 const REMOTE_INSTALL_MARK_DAEMON_CONTACTED_COMMAND: &str = "set -eu; case \"$HOME\" in /*) ;; *) exit 1 ;; esac; IFS= read -r txn; case \"$txn\" in .boomux.bootstrap.[A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9][A-Za-z0-9]) ;; *) exit 2 ;; esac; directory=$HOME/.local/bin; lock=$directory/.boomux.bootstrap.lock; transaction=$directory/$txn; [ \"$(cat \"$lock/id\")\" = \"$txn\" ]; : > \"$transaction/daemon_contacted\"";
@@ -908,6 +916,17 @@ impl RemoteConnection {
             return Err(invalid_probe("remote response version mismatch"));
         }
         Ok(response.message)
+    }
+
+    /// Observe the verified owner's Workspaces before offering first-time setup.
+    /// Connection aliases never identify an existing owner Workspace.
+    pub fn has_workspaces(&mut self, timeout: Duration) -> io::Result<bool> {
+        match self.request(Request::Snapshot, timeout)? {
+            Response::Snapshot { snapshot } => Ok(!snapshot.workspaces.is_empty()),
+            _ => Err(invalid_probe(
+                "remote Workspace discovery returned an unexpected response",
+            )),
+        }
     }
 
     pub fn ping(&mut self) -> io::Result<()> {
@@ -2433,6 +2452,13 @@ impl BootstrapSession {
                 BootstrapRecoveryDisposition::OutcomeUnknown,
             ));
         }
+        // Cleanup failure cannot undo an acknowledged commit. The watchdog
+        // remains the bounded fallback if this final SSH exchange is lost.
+        let _ = run_streaming_command(
+            self.command(REMOTE_INSTALL_FINALIZE_COMMAND),
+            transaction.input(),
+            timeout.min(Duration::from_secs(5)),
+        );
         connection._bootstrap_session = Some(self);
         Ok(connection)
     }
@@ -6651,6 +6677,59 @@ mod tests {
     }
 
     #[test]
+    fn starter_workspace_discovery_uses_owner_state_not_connection_alias() {
+        for (workspaces, expected) in [
+            (serde_json::json!([]), false),
+            (
+                serde_json::json!([{"id":"existing", "name":"original-hostname", "revision":1,
+                "shells":[], "launchers":[], "agents":[]}]),
+                true,
+            ),
+        ] {
+            let handshake = FederationHandshake {
+                version: FEDERATION_VERSION,
+                node_id: Uuid::new_v4().to_string(),
+                helper_version: env!("CARGO_PKG_VERSION").into(),
+                core_protocol_version: protocol::PROTOCOL_VERSION,
+                connection_mode: FederationConnectionMode::AdHoc,
+            };
+            let mut handshake_bytes = Vec::new();
+            crate::federation::write_handshake(&mut handshake_bytes, &handshake).unwrap();
+            let mut request = Vec::new();
+            protocol::write_message(&mut request, &Envelope::new(Request::Snapshot)).unwrap();
+            let snapshot =
+                serde_json::from_value(serde_json::json!({"workspaces":workspaces})).unwrap();
+            let mut response = Vec::new();
+            protocol::write_message(
+                &mut response,
+                &Envelope::new(Response::Snapshot { snapshot }),
+            )
+            .unwrap();
+            let mut command = Command::new("sh");
+            command.args([
+                "-c",
+                &format!(
+                    "{}; dd bs=1 count={} of=/dev/null 2>/dev/null; {}; cat >/dev/null",
+                    shell_printf(&handshake_bytes),
+                    request.len(),
+                    shell_printf(&response)
+                ),
+            ]);
+            let helper = CompatibleRemoteHelper {
+                executable: RemoteExecutable::parse("/remote/boomux").unwrap(),
+                handshake,
+                bootstrap_id: None,
+            };
+            let mut connection =
+                connect_remote_command(command, helper, Duration::from_secs(2), None).unwrap();
+            assert_eq!(
+                connection.has_workspaces(Duration::from_secs(2)).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn helper_probe_verifies_handshake_and_ping_on_one_channel() {
         let handshake = FederationHandshake {
             version: FEDERATION_VERSION,
@@ -8388,6 +8467,48 @@ mod tests {
                 .join(".local/bin/.boomux.bootstrap.lock/committed/backup")
                 .exists()
         );
+        directory.reap_watchdogs();
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn acknowledged_install_cleanup_allows_immediate_remove_and_reinstall() {
+        let directory = runtime_directory();
+        fs::create_dir_all(directory.join(".local/bin")).unwrap();
+        let destination = directory.join(".local/bin/boomux");
+        let lock = directory.join(".local/bin/.boomux.bootstrap.lock");
+        let install = gate_watchdog(REMOTE_INSTALL_COMMAND);
+        let first = run_local_upload_with_command(&directory, b"first", "sh", &install);
+        run_local_activation(&directory, "sh", &first, RemoteInstallReason::Missing);
+        run_local_transaction(&directory, REMOTE_INSTALL_COMMIT_COMMAND, &first);
+        run_local_transaction(&directory, REMOTE_INSTALL_FINALIZE_COMMAND, &first);
+        assert!(!lock.exists());
+        assert_eq!(fs::read(&destination).unwrap(), b"first");
+        fs::remove_file(&destination).unwrap();
+        let second = run_local_upload_with_command(&directory, b"second", "sh", &install);
+        // A delayed cleanup from the first install cannot remove this new lock.
+        run_local_transaction(&directory, REMOTE_INSTALL_FINALIZE_COMMAND, &first);
+        assert!(lock.exists());
+        assert_eq!(
+            fs::read_to_string(lock.join("id")).unwrap().trim(),
+            second.0
+        );
+        // Neither a live upload nor a verified but uncommitted activation is cleanup authority.
+        for activated in [false, true] {
+            if activated {
+                run_local_activation(&directory, "sh", &second, RemoteInstallReason::Missing);
+            }
+            let mut command = local_shell_command("sh", &directory);
+            command.args(["-c", REMOTE_INSTALL_FINALIZE_COMMAND]);
+            assert!(
+                run_streaming_command(command, second.input(), Duration::from_secs(5)).is_err()
+            );
+            assert!(lock.exists());
+        }
+        run_local_transaction(&directory, REMOTE_INSTALL_COMMIT_COMMAND, &second);
+        run_local_transaction(&directory, REMOTE_INSTALL_FINALIZE_COMMAND, &second);
+        assert_eq!(fs::read(&destination).unwrap(), b"second");
+        assert!(!lock.exists());
         directory.reap_watchdogs();
         fs::remove_dir_all(directory).unwrap();
     }


### PR DESCRIPTION
Remote connection setup could leave the current Workspace's panes detached, block immediate reinstall after uninstall, and create an extra starter Workspace when reconnecting with a different alias.

- After an acknowledged install/update commit, promptly claim and retire that exact transaction before removing its lock and rollback files. Delayed cleanup cannot remove a newer transaction. Interrupted cleanup retains the watchdog fallback; active and uncommitted transactions remain protected.
- Open connection, sign-in, update, uninstall, and integration setup terminals as temporary floating panes over the current arrangement. Preserve existing attachments, expanded Workspace, and maximized panes. Exclude setup overlays from saved layouts and return focus to the maximized pane on closure.
- Inspect the verified remote owner's live Workspace snapshot before creating a starter. Reconnecting to an owner with preserved Workspaces, including under a different alias, creates no additional Workspace. Existing Workspaces are neither renamed nor deleted.

Validation: root and Desktop compile checks passed, along with three focused regression tests covering immediate remove/reinstall and delayed cleanup, existing-owner Workspace discovery, and saved layout preservation during setup. Formatting and diff checks passed. No hands-on GUI verification or live remote install/uninstall was performed; comprehensive checks remain with PR CI.
