### PR TITLE
fix(desktop): preserve layouts while creating workspaces

### DIFF
--- a/desktop/src/layout_persistence.rs
+++ b/desktop/src/layout_persistence.rs
@@ -78,6 +78,17 @@ fn decode_tree(node: &Tree, ids: &HashMap<u64, usize>) -> Node {
     }
 }
 impl TerminalPane {
+    fn blocks_workspace_capture(&self) -> bool {
+        // A new Workspace has no identity until creation succeeds. Saving its
+        // loading/error pane under the previous active key erases that layout.
+        !self.temporary_setup
+            && !self.shell.as_ref().is_some_and(|shell| shell.desktop_setup)
+            && self
+                .saved_reference()
+                .and_then(|pane| pane.workspace)
+                .is_none()
+    }
+
     fn saved_reference(&self) -> Option<Pane> {
         if self.temporary_setup || self.shell.as_ref().is_some_and(|shell| shell.desktop_setup) {
             return None;
@@ -163,6 +174,14 @@ impl Workspace {
 
     pub(super) fn capture_arrangement(&mut self) -> bool {
         if self.layout_frozen || self.layout_restoring || self.pointer_drag.is_some() {
+            return false;
+        }
+        if self.workspace_pane_mode == WorkspacePaneMode::Workspace
+            && self
+                .terminals
+                .get(&self.focused)
+                .is_some_and(TerminalPane::blocks_workspace_capture)
+        {
             return false;
         }
         let key = if self.workspace_pane_mode == WorkspacePaneMode::Mixed {
@@ -634,6 +653,26 @@ impl Workspace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn workspace_creation_wait_and_failure_cannot_overwrite_previous_layout() {
+        let mut pane = TerminalPane {
+            attaching: true,
+            ..TerminalPane::default()
+        };
+        assert!(pane.blocks_workspace_capture());
+        pane.attaching = false;
+        pane.error = Some("remote unavailable".into());
+        assert!(pane.blocks_workspace_capture());
+        pane.restored = Some(Pane {
+            shell: Some("shell".into()),
+            workspace: Some("remote-workspace".into()),
+        });
+        assert!(!pane.blocks_workspace_capture());
+        pane.restored = None;
+        pane.temporary_setup = true;
+        assert!(!pane.blocks_workspace_capture());
+    }
+
     #[test]
     fn setup_overlay_does_not_replace_saved_workspace_or_panes() {
         let reference = Pane {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -5585,10 +5585,6 @@ impl Workspace {
         self.sidebar_menu = None;
         self.navigation_region = NavigationRegion::Terminal;
         let temporary_setup = launch.temporary_setup();
-        if !temporary_setup {
-            self.fullscreen = None;
-            self.layout_animation = None;
-        }
         let pane_id = if temporary_setup {
             // A setup terminal is an overlay, not navigation to another Workspace.
             self.capture_arrangement();
@@ -5611,6 +5607,8 @@ impl Workspace {
             if self.workspace_pane_mode == WorkspacePaneMode::Workspace {
                 self.detach_all_panes(window);
             }
+            self.fullscreen = None;
+            self.layout_animation = None;
             self.insert_pane()
         };
         self.focused = pane_id;


### PR DESCRIPTION
Creating a remote Workspace replaces the current panes with an unbound loading pane. When creation takes longer than the layout-save debounce, capture falls back to the previous active Workspace key and can replace its saved arrangement with an empty layout. Returning to that Workspace then leaves its Shells closed in Desktop.

Skip Workspace-scoped capture while the focused ordinary pane has no Workspace identity, including creation failures. Temporary setup overlays still allow the underlying layout to save. Capture the outgoing layout before clearing maximized state.

Validation: Desktop cargo check and the focused regression covering loading, failure, resolved identity, and temporary setup passed. Live UI reproduction has not been performed; existing layouts already overwritten cannot be reconstructed by this fix.
